### PR TITLE
Don't use bash to read key.

### DIFF
--- a/cfg-update
+++ b/cfg-update
@@ -3,6 +3,7 @@ use strict;
 use File::Basename;
 use Getopt::Long qw(:config bundling permute pass_through);
 use Term::ANSIColor qw(:constants);
+use Term::ReadKey;
 $Term::ANSIColor::AUTORESET = 1;
 
 #
@@ -458,8 +459,9 @@ sub strip_comment{ #ARGS# ("linefromfile")
 
 sub readkey{
     if ($opt_d >= 1) { print "\n$tab"."<readkey>\n"; $tab = $tab."    "; print "$tab"; }
-    $ENV{readkey}=q{() { read -n1 -r; printf "$REPLY"; }};   #
-    $key = `bash -c readkey`;                                # read a single key
+    ReadMode 4; # Turn off controls keys
+    $key = ReadKey 0;
+    ReadMode 0; # Reset tty mode
     print "$tab"."\n";                                       #
     if ($opt_d >= 1) { $tab =~ s/    //; print "$tab"."</readkey>\n"; }
 }
@@ -2477,8 +2479,9 @@ sub breakpoint { #ARGS# ("variable-1,variable-2,..")
         print "$tab"."   value $i = $_[$i]\n";
     }
     print "$tab"."Press [q] to quit or another key to continue...  ";
-    $ENV{readkey}=q{() { read -n1 -r; printf "$REPLY"; }};   #
-    my $key = `bash -c readkey`;                             # read a single key
+    ReadMode 4; # Turn off controls keys
+    my $key = ReadKey 0;
+    ReadMode 0; # Reset tty mode
     print "$tab"."\n";                                       #
     print "$tab"."$bar2\n";
     if ($opt_d >= 1) { $tab =~ s/    //; print "$tab"."</breakpoint>\n"; }


### PR DESCRIPTION
After security-updates to bash it's no longer possible to store
functions in envirinment.  This patch replaces use of bash to read a
single key from tty with the perl-module Term::ReadKey
