### PR TITLE
Add Gentoo ebuild reference and merge uninit-value fix

### DIFF
--- a/cfg-update
+++ b/cfg-update
@@ -998,7 +998,7 @@ sub determine_state{ #DEPS# (requires that global variable $file1 contains a fil
         chomp ($md5sum_index = `grep "$file1_without_host " "$host_path$index_file" $debug | cut -d" " -f2 $debug`);
         if ($opt_d >= 1) { print "$tab"."  MD5 checksum in the checksum-index  : $md5sum_index\n"; }
         if ($md5sum_index =~ /.+/) {
-            if ($md5sum_index !~ $md5sum_file) {
+            if (length($md5sum_file) && $md5sum_index !~ $md5sum_file) {
                 $state = $state1; $vstate = $vstate1;                               #  1 = MF = Modified File     - checksum differs from index
                 if (-B "$file1") { $state = $state2; $vstate = $vstate2; }          #  2 = MB = Modified Binary   - you probably replaced the binary file so replace not allowed
             } else {

--- a/gentoo/cfg-update-1.8.9-r3.ebuild
+++ b/gentoo/cfg-update-1.8.9-r3.ebuild
@@ -1,0 +1,106 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+#
+# Vendored from ::gentoo app-portage/cfg-update/cfg-update-1.8.9-r3.ebuild
+# https://gitweb.gentoo.org/repo/gentoo.git/tree/app-portage/cfg-update/cfg-update-1.8.9-r3.ebuild
+# Gentoo's uninit-value patch (bugs.gentoo.org/829993) is merged in cfg-update.
+
+EAPI=8
+
+DESCRIPTION="Easy to use GUI & CLI alternative for etc-update"
+HOMEPAGE="https://github.com/rich0/cfg-update"
+SRC_URI="https://github.com/rich0/cfg-update/archive/${PV}.tar.gz -> ${P}.tgz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="amd64 ~arm ~arm64 ppc x86"
+IUSE="X"
+
+RDEPEND="
+	dev-perl/TermReadKey
+	X? (
+		>=x11-misc/sux-1.0
+		x11-apps/xhost
+		)"
+
+S="${WORKDIR}/rich0-cfg-update-${PV}"
+
+pkg_prerm() {
+	if [[ -z ${ROOT} ]]
+	then
+		ebegin "Disabling portage hook"
+		cfg-update --ebuild --disable-portage-hook
+		eend $?
+		ebegin "Disabling paludis hook"
+		cfg-update --ebuild --disable-paludis-hook
+		eend $?
+	fi
+}
+
+pkg_postrm() {
+	echo
+	ewarn "If you want to permanently remove cfg-update from your system"
+	ewarn "you should remove the index file /var/lib/cfg-update/checksum.index"
+	echo
+}
+
+src_install() {
+	dobin \
+		cfg-update emerge_with_indexing_for_cfg-update \
+		emerge_with_indexing_for_cfg-update_phphelper \
+		cfg-update_phphelper emerge_with_indexing_for_cfg-update_bashhelper
+	insinto /usr/lib/cfg-update
+	doins cfg-update cfg-update_indexing test.tgz
+	dodoc ChangeLog
+	doman *.8
+	insinto /etc
+	doins cfg-update.conf cfg-update.hosts
+	keepdir /var/lib/cfg-update
+}
+
+pkg_postinst() {
+	if [[ ! -e "${ROOT}"/var/lib/cfg-update/checksum.index \
+		&& -e "${ROOT}"/var/lib/cfg-update/checksum.index ]]
+	then
+		ebegin "Moving checksum.index from /usr/lib/cfg-update to /var/lib/cfg-update"
+		mv "${ROOT}"/usr/lib/cfg-update/checksum.index \
+			"${ROOT}"/var/lib/cfg-update/checksum.index
+		eend $?
+	fi
+
+	if [[ -e "${ROOT}"/usr/bin/paludis ]]
+	then
+		echo
+		ewarn "If you have used Paludis version <0.20.0 on your system, chances are"
+		ewarn "that you have some corrupted CONTENTS files on your system..."
+		echo
+		ewarn "Please run: cfg-update --check-packages"
+		echo
+		ewarn "The above command will check all packages installed with Paludis and"
+		ewarn "will output a list of packages that need to be re-installed with"
+		ewarn "Paludis 0.20.0 or higher. If you do not re-install these packages"
+		ewarn "you risk losing your custom settings when updating configuration"
+		ewarn "files, that belong to these packages, with cfg-update!"
+		echo
+	fi
+
+	if [[ -z ${ROOT} ]]
+	then
+		ebegin "Moving backups to /var/lib/cfg-update/backups"
+		/usr/bin/cfg-update --ebuild --move-backups
+		eend $?
+	fi
+
+	echo
+	einfo "If this is a first time install, please check the configuration"
+	einfo "in /etc/cfg-update.conf before using cfg-update:"
+	echo
+	einfo "If your system does not have an X-server installed you need to"
+	einfo "change the MERGE_TOOL to sdiff, imediff2 or vimdiff."
+	einfo "If you have X installed, set MERGE_TOOL to your favorite GUI tool:"
+	einfo "xxdiff, beediff, kdiff3, meld (default), gtkdiff, gvimdiff, tkdiff"
+	echo
+	einfo "TIP: to maximize the chances of future automatic updates, run:"
+	einfo "cfg-update --optimize-backups"
+	echo
+}


### PR DESCRIPTION
Vendor cfg-update-1.8.9-r3.ebuild under gentoo/ (PATCHES removed; bugs.gentoo.org/829993 fix applied directly in determine_state).