### PR TITLE
Add Tier E tests for Portage cfg-update --index

### DIFF
--- a/cfg-update
+++ b/cfg-update
@@ -36,6 +36,7 @@ $Term::ANSIColor::AUTORESET = 1;
 # Set default settings...
     my $pkg_manager       = "Portage";
     my $install_log       = "/var/log/emerge.log";
+    my $install_log_configured = 0;
     my $find_string       = "::: completed emerge";
     my $pkg_db            = "/var/db/pkg";
     my $portage_hook      = "/etc/portage/bashrc";
@@ -86,6 +87,7 @@ $Term::ANSIColor::AUTORESET = 1;
         if ($line =~ /^\s*INDEXFILE\s*=\s*/i)         { $index_file        = &strip($'); }
         if ($line =~ /^\s*INDEX_FILE\s*=\s*/i)        { $index_file        = &strip($'); }
         if ($line =~ /^\s*PKG_DB\s*=\s*/i)            { $pkg_db            = &strip($'); }
+        if ($line =~ /^\s*INSTALL_LOG\s*=\s*/i)       { $install_log = &strip($'); $install_log_configured = 1; }
         if ($line =~ /^\s*PORTAGE_HOOK\s*=\s*/i)      { $portage_hook      = &strip($'); }
         if ($line =~ /^\s*PALUDIS_HOOK\s*=\s*/i)      { $paludis_hook      = &strip($'); }
         if ($line =~ /^\s*LOGFILE\s*=\s*/i)           { $log_file          = &strip($'); }
@@ -370,13 +372,13 @@ $Term::ANSIColor::AUTORESET = 1;
 # If --paludis is used then set the package manager to Paludis...
     if ($opt_paludis > 0) {
         $pkg_manager = "Paludis";
-        $install_log = "/var/log/paludis.log";
+        if (!$install_log_configured) { $install_log = "/var/log/paludis.log"; }
         $find_string = "finished install of package";
     }
 # Else set the package manager to Portage...
     else {
         $pkg_manager = "Portage";
-        $install_log = "/var/log/emerge.log";
+        if (!$install_log_configured) { $install_log = "/var/log/emerge.log"; }
         $find_string = "::: completed emerge";
     }
 # If debug mode is detected show most important variables...
@@ -396,7 +398,7 @@ $Term::ANSIColor::AUTORESET = 1;
     }
 # If --index is used then check/build index...
     if ($opt_i > 0) {
-        &root_only;
+        &root_only unless &sandbox_mode;
         &check_index;
         exit;
     }

--- a/cfg-update.conf
+++ b/cfg-update.conf
@@ -146,6 +146,7 @@ ENABLE_STAGE5 = yes
 # BACKUP_PATH  = /var/lib/cfg-update/backups               # this is where cfg-update will save the backups
 # INDEX_FILE   = /var/lib/cfg-update/checksum.index        # this file contains all MD5 checksums for the host
 # PKG_DB       = /var/db/pkg                               # this directory contains the CONTENTS files (you can change it when your system uses another location)
+# INSTALL_LOG  = /var/log/emerge.log                       # emerge log used by --index to detect stale checksum indexes (Portage)
 # PALUDIS_HOOK = /usr/share/paludis/hooks/install_all_pre/cfg-update.bash  # best-effort; override if your Paludis hook path differs
 # HOSTS_FILE   = /etc/cfg-update.hosts                     # DEPRECATED: legacy sshfs multi-host settings (see cfg-update.hosts)
 # XXDIFF_STYLE = "--style Keramik"                         # this variable controls the style of xxdiff

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -329,7 +329,7 @@ Legacy archive [`test.tgz`](../test.tgz) (still shipped in the ebuild) contained
 
 Each scenario has `etc/` (live + `._cfg*` files), optional `backups/etc/test/` (ancestors), `checksum.index.entry`, and `scenario.md`. Combined index: `test/fixtures/checksum.index.seed`. Legacy setup script: `test/fixtures/legacy/prepare_cfg-update_test`.
 
-**Stage 6b (done):** [`test/run-tests.sh`](../test/run-tests.sh) Tier 0/A, [`test/lint-fixtures.sh`](../test/lint-fixtures.sh). **Stage 6c:** sandbox `root_only` bypass for `-u` with `--testsandbox` + `--ebuild`; ebuild `src_test()` via `FEATURES=test`. CI/Renovate deferred.
+**Stage 6b (done):** [`test/run-tests.sh`](../test/run-tests.sh) Tier 0/A, [`test/lint-fixtures.sh`](../test/lint-fixtures.sh). **Stage 6c:** sandbox `root_only` bypass for `-u` and `--index` with `--testsandbox` + `--ebuild`; ebuild `src_test()` via `FEATURES=test`. **Tier E:** Portage `--index` via [`test/fixtures/index-portage/`](../test/fixtures/index-portage/) (Paludis not covered). CI/Renovate deferred.
 
 ---
 

--- a/test/README.md
+++ b/test/README.md
@@ -60,8 +60,9 @@ FEATURES=test USE=test emerge --oneshot app-portage/cfg-update
 | B | `-p -au` | Stages 1–2 pretend; live files unchanged |
 | C | `-au` | Stages 1–2 execute: golden file equality, binary MD5, 3-way conflict handling, stage 3 re-list |
 | D | `-mu` + stdin | Stages 3–5 execute: replace/keep filesystem outcomes (non-interactive via sandbox STDIN) |
+| E | `-i` / `-i -f` | Portage `--index`: up-to-date skip, stale rebuild from mock CONTENTS, marker-blocked skip, force rebuild |
 
-Tier B/C/D pass `--testsandbox` with `--ebuild` so `-u` skips the root check inside the temp sandbox.
+Tier B/C/D/E pass `--testsandbox` with `--ebuild` so `-u` and `--index` skip the root check inside the temp sandbox.
 
 ### Golden `expected/` files
 
@@ -71,7 +72,7 @@ The harness prepends a mock `portageq` to `PATH` that returns the sandbox `etc/t
 
 ### Sandbox mode (stage 6c)
 
-When `--testsandbox` and `--ebuild` are passed, `cfg-update -u` skips the root check so the harness and ebuild `src_test()` can run Tier B/C/D as an unprivileged user. In the same mode, `readkey` reads from STDIN when piped (enabling Tier D). `CFG_UPDATE_CONF` only selects the config file path; production `-u` still requires root.
+When `--testsandbox` and `--ebuild` are passed, `cfg-update -u` and `cfg-update --index` skip the root check so the harness and ebuild `src_test()` can run Tier B/C/D/E as an unprivileged user. Tier E uses mock `PKG_DB`, `INSTALL_LOG`, and `portageq` under [`fixtures/index-portage/`](fixtures/index-portage/). In the same mode, `readkey` reads from STDIN when piped (enabling Tier D). `CFG_UPDATE_CONF` only selects the config file path; production `-u`/`--index` still require root.
 
 ### Manual single-scenario check (Gentoo host)
 

--- a/test/fixtures/index-portage/checksum.index.current
+++ b/test/fixtures/index-portage/checksum.index.current
@@ -1,0 +1,2 @@
+Portage:1690000000
+@SANDBOX@/etc/test/test_unmodified_file e2dda9550032d229538e6ae35652ca6d

--- a/test/fixtures/index-portage/checksum.index.stale
+++ b/test/fixtures/index-portage/checksum.index.stale
@@ -1,0 +1,2 @@
+Portage:1000000000
+@SANDBOX@/etc/test/test_unmodified_file deadbeefdeadbeefdeadbeefdeadbeef

--- a/test/fixtures/index-portage/emerge.log.current
+++ b/test/fixtures/index-portage/emerge.log.current
@@ -1,0 +1,2 @@
+1000000000: ::: completed emerge (app-test/old-pkg-0.9:0/1::test)
+1690000000: ::: completed emerge (app-test/test-pkg-1.0:0/1::test)

--- a/test/fixtures/index-portage/emerge.log.stale
+++ b/test/fixtures/index-portage/emerge.log.stale
@@ -1,0 +1,1 @@
+1000000000: ::: completed emerge (app-test/test-pkg-1.0:0/1::test)

--- a/test/fixtures/index-portage/etc/test_unmodified_file
+++ b/test/fixtures/index-portage/etc/test_unmodified_file
@@ -1,0 +1,3 @@
+#version 1.0
+
+SETTING = default # contains a default value chosen by the developer

--- a/test/fixtures/index-portage/scenario.md
+++ b/test/fixtures/index-portage/scenario.md
@@ -1,0 +1,27 @@
+# Index — Portage `--index` rebuild (Tier E)
+
+**Package manager:** Portage only  
+**Purpose:** Exercise `check_index` / `build_index` against mock `emerge.log` and `CONTENTS`.
+
+## Files
+
+| File | Role |
+|------|------|
+| `etc/test_unmodified_file` | Live config indexed by CONTENTS |
+| `var/db/pkg/app-test/test-pkg-1.0/CONTENTS.template` | `obj @SANDBOX@/etc/test/test_unmodified_file {md5}` |
+| `emerge.log.current` | Last emerge timestamp `1690000000` |
+| `emerge.log.stale` | Older emerge timestamp `1000000000` |
+| `checksum.index.current` | Golden index after rebuild (`Portage:1690000000`) |
+| `checksum.index.stale` | Stale index header + wrong MD5 body |
+
+Paths use `@SANDBOX@` placeholder; the harness substitutes the temp sandbox path at deploy time.
+
+## Expected behavior (Tier E)
+
+| Case | Condition | Result |
+|------|-----------|--------|
+| E1 | Index ts matches emerge.log | Skip rebuild |
+| E2 | Stale index, no `._cfg*` markers | Rebuild from CONTENTS |
+| E3 | Stale index + pending marker | Skip rebuild (markers block) |
+| E4 | E3 + `--force` | Rebuild anyway |
+| E5 | After E2 rebuild | `-lv` shows Stage 1 UF for live file |

--- a/test/fixtures/index-portage/var/db/pkg/app-test/test-pkg-1.0/CONTENTS.template
+++ b/test/fixtures/index-portage/var/db/pkg/app-test/test-pkg-1.0/CONTENTS.template
@@ -1,0 +1,1 @@
+obj @SANDBOX@/etc/test/test_unmodified_file e2dda9550032d229538e6ae35652ca6d

--- a/test/lint-fixtures.sh
+++ b/test/lint-fixtures.sh
@@ -99,6 +99,37 @@ lint_execute_scenarios_have_expected() {
     done
 }
 
+lint_index_portage_fixture() {
+    local fixture="$FIXTURES/index-portage"
+    local name="index-portage"
+    [[ -d "$fixture/etc" ]] || { fail "$name: missing etc/"; return; }
+    [[ -f "$fixture/etc/test_unmodified_file" ]] || { fail "$name: missing live file"; return; }
+    [[ -f "$fixture/var/db/pkg/app-test/test-pkg-1.0/CONTENTS.template" ]] || {
+        fail "$name: missing CONTENTS.template"; return
+    }
+    local live_hash contents_hash golden_hash
+    live_hash="$(md5sum "$fixture/etc/test_unmodified_file" | awk '{print $1}')"
+    contents_hash="$(awk '{print $3}' "$fixture/var/db/pkg/app-test/test-pkg-1.0/CONTENTS.template")"
+    golden_hash="$(awk 'NR==2 {print $2}' "$fixture/checksum.index.current")"
+    if [[ "$live_hash" == "$contents_hash" ]]; then
+        pass "$name: CONTENTS MD5 matches live file"
+    else
+        fail "$name: CONTENTS MD5 mismatch (template $contents_hash, live $live_hash)"
+    fi
+    if [[ "$live_hash" == "$golden_hash" ]]; then
+        pass "$name: golden index MD5 matches live file"
+    else
+        fail "$name: golden index MD5 mismatch (golden $golden_hash, live $live_hash)"
+    fi
+    for f in emerge.log.current emerge.log.stale checksum.index.current checksum.index.stale; do
+        if [[ -f "$fixture/$f" ]]; then
+            pass "$name: has $f"
+        else
+            fail "$name: missing $f"
+        fi
+    done
+}
+
 lint_duplicate_markers() {
     local combined
     combined="$(mktemp)"
@@ -123,6 +154,7 @@ main() {
         lint_expected_files "$scenario"
     done
     lint_execute_scenarios_have_expected
+    lint_index_portage_fixture
     lint_duplicate_markers
     echo ""
     echo "Results: $PASS passed, $FAIL failed"

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 FIXTURES="$REPO_ROOT/test/fixtures"
+INDEX_FIXTURE="$FIXTURES/index-portage"
 CFG_UPDATE="$REPO_ROOT/cfg-update"
 HOSTS_FILE="$REPO_ROOT/test/cfg-update.hosts"
 LINT_FIXTURES="$REPO_ROOT/test/lint-fixtures.sh"
@@ -229,6 +230,86 @@ run_cfg_update_stdin() {
     shift
     local extra_args=("$@")
     printf '%b' "$keys" | run_cfg_update "${extra_args[@]}"
+}
+
+remap_sandbox_paths() {
+    sed "s|@SANDBOX@|$SANDBOX|g" "$1"
+}
+
+write_index_test_config() {
+    local conf="$1" index="$2" backup="$3" pkg_db="$4" install_log="$5"
+    cat >"$conf" <<EOF
+MERGE_TOOL = /usr/bin/diff3
+ENABLE_BACKUPS = yes
+ENABLE_STAGE1 = yes
+ENABLE_STAGE2 = yes
+ENABLE_STAGE3 = yes
+ENABLE_STAGE4 = yes
+ENABLE_STAGE5 = yes
+INDEX_FILE = $index
+BACKUP_PATH = $backup
+PKG_DB = $pkg_db
+INSTALL_LOG = $install_log
+EOF
+}
+
+setup_index_sandbox() {
+    local index_variant="$1"
+    local emerge_variant="$2"
+    local with_marker="${3:-no}"
+
+    SANDBOX="$(mktemp -d)"
+    export CFG_UPDATE_TEST_SANDBOX="$SANDBOX"
+
+    mkdir -p "$SANDBOX/etc/test" \
+             "$SANDBOX/var/lib/cfg-update/backups" \
+             "$SANDBOX/var/log" \
+             "$SANDBOX/var/db/pkg/app-test/test-pkg-1.0" \
+             "$SANDBOX/bin"
+
+    cat >"$SANDBOX/bin/portageq" <<'EOF'
+#!/bin/bash
+echo "\"${CFG_UPDATE_TEST_SANDBOX}/etc/test\""
+EOF
+    chmod +x "$SANDBOX/bin/portageq"
+
+    cp -a "$INDEX_FIXTURE/etc/test_unmodified_file" "$SANDBOX/etc/test/"
+    if [[ "$with_marker" == yes ]]; then
+        cp -a "$FIXTURES/stage1-unmodified-text/etc/._cfg0000_test_unmodified_file" \
+            "$SANDBOX/etc/test/"
+    fi
+
+    remap_sandbox_paths "$INDEX_FIXTURE/var/db/pkg/app-test/test-pkg-1.0/CONTENTS.template" \
+        >"$SANDBOX/var/db/pkg/app-test/test-pkg-1.0/CONTENTS"
+    cp "$INDEX_FIXTURE/emerge.log.$emerge_variant" "$SANDBOX/var/log/emerge.log"
+    remap_sandbox_paths "$INDEX_FIXTURE/checksum.index.$index_variant" \
+        >"$SANDBOX/var/lib/cfg-update/checksum.index"
+
+    write_index_test_config \
+        "$SANDBOX/etc/cfg-update.conf" \
+        "$SANDBOX/var/lib/cfg-update/checksum.index" \
+        "$SANDBOX/var/lib/cfg-update/backups" \
+        "$SANDBOX/var/db/pkg" \
+        "$SANDBOX/var/log/emerge.log"
+}
+
+index_golden_path() {
+    remap_sandbox_paths "$INDEX_FIXTURE/checksum.index.current"
+}
+
+assert_index_header() {
+    local desc="$1" file="$2" expected_ts="$3"
+    local header
+    header="$(head -1 "$file")"
+    if [[ "$header" == "Portage:$expected_ts" ]]; then
+        pass "$desc"
+    else
+        fail "$desc (expected Portage:$expected_ts, got: $header)"
+    fi
+}
+
+run_cfg_update_index() {
+    run_cfg_update -i "$@"
 }
 
 tier0_static() {
@@ -548,6 +629,57 @@ tier_d_execute_manual() {
         "$SANDBOX/etc/test/._cfg0000_test_link_2_link"
 }
 
+tier_e_index_portage() {
+    echo "=== Tier E: Portage --index (-i) ==="
+    local output golden index_before
+
+    setup_index_sandbox current current
+    index_before="$(mktemp)"
+    cp "$SANDBOX/var/lib/cfg-update/checksum.index" "$index_before"
+    output="$(run_cfg_update_index 2>&1)" || true
+    assert_output_matches "index up-to-date skips rebuild" \
+        'Checksum index is up-to-date' "$output"
+    assert_file_equals "index up-to-date left file unchanged" \
+        "$SANDBOX/var/lib/cfg-update/checksum.index" "$index_before"
+    rm -f "$index_before"
+
+    setup_index_sandbox stale current
+    golden="$(mktemp)"
+    index_golden_path >"$golden"
+    run_cfg_update_index >/dev/null
+    assert_index_header "index stale rebuild updated header" \
+        "$SANDBOX/var/lib/cfg-update/checksum.index" "1690000000"
+    assert_file_equals "index stale rebuild matches golden" \
+        "$SANDBOX/var/lib/cfg-update/checksum.index" "$golden"
+    rm -f "$golden"
+
+    setup_index_sandbox stale current yes
+    index_before="$(mktemp)"
+    cp "$SANDBOX/var/lib/cfg-update/checksum.index" "$index_before"
+    output="$(run_cfg_update_index 2>&1)" || true
+    assert_output_matches "index marker present skips rebuild" \
+        'Skipping checksum index updating' "$output"
+    assert_file_equals "index marker present left file unchanged" \
+        "$SANDBOX/var/lib/cfg-update/checksum.index" "$index_before"
+    rm -f "$index_before"
+
+    setup_index_sandbox stale current yes
+    run_cfg_update_index -f >/dev/null
+    assert_index_header "index force rebuild uses zero timestamp" \
+        "$SANDBOX/var/lib/cfg-update/checksum.index" "0000000000"
+    assert_file_contains "index force rebuild has indexed path" \
+        "$SANDBOX/var/lib/cfg-update/checksum.index" \
+        "$SANDBOX/etc/test/test_unmodified_file e2dda9550032d229538e6ae35652ca6d"
+
+    setup_index_sandbox stale current
+    run_cfg_update_index >/dev/null
+    cp -a "$FIXTURES/stage1-unmodified-text/etc/._cfg0000_test_unmodified_file" \
+        "$SANDBOX/etc/test/"
+    output="$(run_cfg_update -lv 2>&1)" || true
+    assert_output_matches "index rebuild enables stage1 classify" \
+        'Stage\[1\][[:space:]]+Unmodified File[[:space:]].*_cfg0000_test_unmodified_file' "$output"
+}
+
 main() {
     parse_args "$@"
 
@@ -571,6 +703,7 @@ main() {
     tier_b_pretend_auto
     tier_c_execute_auto
     tier_d_execute_manual
+    tier_e_index_portage
 
     echo ""
     echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"


### PR DESCRIPTION
Introduce index-portage fixture with mock emerge.log, CONTENTS, and golden/stale checksum indexes. Tier E covers up-to-date skip, stale rebuild, marker-blocked skip, --force rebuild, and post-rebuild stage classification.

cfg-update: honor INSTALL_LOG from config (do not overwrite after parse), and allow --index without root in --testsandbox mode.