### PR TITLE
Strengthen stage 3–5 merge-mode tests with behavioral assertions

### DIFF
--- a/cfg-update
+++ b/cfg-update
@@ -475,8 +475,14 @@ sub strip_comment{ #ARGS# ("linefromfile")
 sub readkey{
     if ($opt_d >= 1) { print "\n$tab"."<readkey>\n"; $tab = $tab."    "; print "$tab"; }
     if (&sandbox_mode && !-t STDIN) {
-        chomp($key = <STDIN>);
-        print "$tab"."$key\n";
+        my $line = <STDIN>;
+        if (!defined $line) {
+            $key = "s";
+            print "$tab"."s\n";
+        } else {
+            chomp($key = $line);
+            print "$tab"."$key\n";
+        }
     } else {
         ReadMode 4; # Turn off controls keys
         $key = ReadKey 0;
@@ -1443,7 +1449,15 @@ sub update_stage4{ #ARGS# ("pretend|execute")
         print BOLD BLUE "$tab"."<< Stage4 >> ".@stage4_queue." files in queue for manual 2-way merging, skipping...\n\n";
     } else {
         print BOLD BLUE "$tab"."<< Stage4 >> ".@stage4_queue." files in queue for manual 2-way merging, starting...\n\n";
-        if ($merge_tool_name =~ /^diff3$/) { print "$tab"."* diff3 cannot be used for this stage, changing to sdiff\n\n"; $merge_tool = "/usr/bin/sdiff"; }
+        if ($merge_tool_name =~ /^diff3$/) {
+            print "$tab"."* diff3 cannot be used for this stage, changing to sdiff\n\n";
+            if (&sandbox_mode && $ENV{CFG_UPDATE_TEST_SANDBOX} && -x "$ENV{CFG_UPDATE_TEST_SANDBOX}/bin/sdiff") {
+                $merge_tool = "$ENV{CFG_UPDATE_TEST_SANDBOX}/bin/sdiff";
+            } else {
+                $merge_tool = "/usr/bin/sdiff";
+            }
+            $merge_tool_name = basename($merge_tool);
+        }
         $threeway_update = "no";
         for (my $i = 0; $i < @stage4_queue; ++$i) {
             &prepare_filenames_for_updating($stage4_queue[$i]);

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -277,12 +277,20 @@ assert_stage_output() {
                 'manual 3-way merging, starting' "$output"
             assert_output_not_matches "$desc: not 2-way mode" \
                 'manual 2-way merging, starting' "$output"
+            assert_output_not_matches "$desc: no stage4 diff3 switch" \
+                'diff3 cannot be used for this stage' "$output"
+            assert_output_not_matches "$desc: offers merge tool" \
+                'This update cannot be done with the diff/merge tool' "$output"
             ;;
         4)
             assert_output_matches "$desc: 2-way merge mode" \
                 'manual 2-way merging, starting' "$output"
             assert_output_not_matches "$desc: not 3-way mode" \
                 'manual 3-way merging, starting' "$output"
+            assert_output_matches "$desc: stage4 diff3-to-sdiff switch" \
+                'diff3 cannot be used for this stage, changing to sdiff' "$output"
+            assert_output_not_matches "$desc: no stage5 non-merge path" \
+                'This update cannot be done with the diff/merge tool' "$output"
             ;;
         5)
             assert_output_matches "$desc: manual update mode" \
@@ -291,8 +299,37 @@ assert_stage_output() {
                 'manual 3-way merging, starting' "$output"
             assert_output_not_matches "$desc: not 2-way mode" \
                 'manual 2-way merging, starting' "$output"
+            assert_output_not_matches "$desc: no stage4 diff3 switch" \
+                'diff3 cannot be used for this stage' "$output"
+            assert_output_not_matches "$desc: no merge-tool offer" \
+                'Merge manually with file' "$output"
             ;;
     esac
+}
+
+install_mock_sdiff() {
+    local golden_merge="${1:-}"
+    cat >"$SANDBOX/bin/sdiff" <<'EOF'
+#!/bin/bash
+log="${CFG_UPDATE_TEST_SANDBOX}/mock-sdiff.log"
+echo "$*" >>"$log"
+outfile=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -o) outfile="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+echo "TWO_WAY=yes" >>"$log"
+if [[ -n "$outfile" && -f "${CFG_UPDATE_TEST_SANDBOX}/golden.merge" ]]; then
+    cp "${CFG_UPDATE_TEST_SANDBOX}/golden.merge" "$outfile"
+fi
+exit 0
+EOF
+    chmod +x "$SANDBOX/bin/sdiff"
+    if [[ -n "$golden_merge" ]]; then
+        cp "$golden_merge" "$SANDBOX/golden.merge"
+    fi
 }
 
 remap_sandbox_paths() {
@@ -639,6 +676,21 @@ tier_d_execute_manual() {
     assert_file_equals "stage3 mock merge matches golden" \
         "$SANDBOX/etc/test/test_auto_3way_conflict" \
         "$FIXTURES/stage2-3way-merge-conflict/expected/test_auto_3way_conflict.after_replace"
+
+    # Stage 4: mock sdiff must run 2-way merge (no -b ancestor)
+    setup_sandbox stage4-manual-2way stage4_only
+    install_mock_sdiff "$FIXTURES/stage4-manual-2way/expected/test_manual_2way"
+    output="$(run_cfg_update_stdin $'y\n1\ny\n1\n' -u 2>&1)" || true
+    assert_stage_output "stage4 manual mock merge" 4 "$output"
+    assert_output_matches "stage4 switches diff3 to sdiff" \
+        'diff3 cannot be used for this stage, changing to sdiff' "$output"
+    assert_file_contains "stage4 mock sdiff used 2-way merge" \
+        "$SANDBOX/mock-sdiff.log" "TWO_WAY=yes"
+    assert_file_equals "stage4 mock merge matches golden" \
+        "$SANDBOX/etc/test/test_manual_2way" \
+        "$FIXTURES/stage4-manual-2way/expected/test_manual_2way"
+    assert_missing "stage4 mock merge removed cfg0000 marker" \
+        "$SANDBOX/etc/test/._cfg0000_test_manual_2way"
 
     # Stage 4: replace (MF, no ancestor — must not run stage 3/5 handlers)
     setup_sandbox stage4-manual-2way stage4_only


### PR DESCRIPTION
Replace SANDBOX_HANDLER_STAGE debug fingerprints with stage-specific prompt and code-path checks so tests verify real behavior (merge tool invocation, diff3→sdiff switch, filesystem results) rather than test-only stdout markers.

Fix sandbox readkey EOF to default to skip, preventing infinite loops when piped stdin runs out during interactive stage prompts. Route stage 4 sdiff through the sandbox mock when running under --testsandbox.