### PR TITLE
Refactor stage numbers to descriptions (issue #16)

### DIFF
--- a/cfg-update
+++ b/cfg-update
@@ -4,6 +4,18 @@ use File::Basename;
 use Getopt::Long qw(:config bundling permute pass_through);
 use Term::ANSIColor qw(:constants);
 use Term::ReadKey;
+use constant {
+    STATE_UNKNOWN => '--',
+    STATE_MF      => 'MF',
+    STATE_MB      => 'MB',
+    STATE_UF      => 'UF',
+    STATE_UB      => 'UB',
+    STATE_CF      => 'CF',
+    STATE_CB      => 'CB',
+    STATE_LF      => 'LF',
+    STATE_FL      => 'FL',
+    STATE_LL      => 'LL',
+};
 $Term::ANSIColor::AUTORESET = 1;
 
 #
@@ -154,27 +166,19 @@ $Term::ANSIColor::AUTORESET = 1;
     my $spacer        = "$progname $version"; $spacer =~ s/./ /g;
     my $package       = "";
     my $state         = "";
-    my $state0        = "--";
-    my $state1        = "MF";
-    my $state2        = "MB";
-    my $state3        = "UF";
-    my $state4        = "UB";
-    my $state5        = "CF";
-    my $state6        = "CB";
-    my $state7        = "LF";
-    my $state8        = "FL";
-    my $state9        = "LL";
     my $vstate        = "";
-    my $vstate0       = "No index found   ";
-    my $vstate1       = "Modified File    ";
-    my $vstate2       = "Modified Binary  ";
-    my $vstate3       = "Unmodified File  ";
-    my $vstate4       = "Unmodified Binary";
-    my $vstate5       = "Custom File      ";
-    my $vstate6       = "Custom Binary    ";
-    my $vstate7       = "Link to File     ";
-    my $vstate8       = "File to Link     ";
-    my $vstate9       = "Link to Link     ";
+    my %STATE_DESC    = (
+        '--' => 'No index found   ',
+        'MF' => 'Modified File    ',
+        'MB' => 'Modified Binary  ',
+        'UF' => 'Unmodified File  ',
+        'UB' => 'Unmodified Binary',
+        'CF' => 'Custom File      ',
+        'CB' => 'Custom Binary    ',
+        'LF' => 'Link to File     ',
+        'FL' => 'File to Link     ',
+        'LL' => 'Link to Link     ',
+    );
 ###    my $indexing_complete = "undefined";
     my $md5sum;
     my $md5sum_file;
@@ -450,6 +454,19 @@ $Term::ANSIColor::AUTORESET = 1;
 sub test_code{ #RUNMODE# --test
 # Add your test code here and run "cfg-update --test" to execute it...
     print "Nothing to test...\n";
+}
+
+sub state_is { #ARGS# ($state, @codes)
+    my ($s, @codes) = @_;
+    for my $code (@codes) {
+        return 1 if $s eq $code;
+    }
+    return 0;
+}
+
+sub state_label { #ARGS# ($state)
+    my ($s) = @_;
+    return $STATE_DESC{$s} // 'Unknown state    ';
 }
 
 sub strip{ #ARGS# ("linefromfile")
@@ -1032,22 +1049,23 @@ sub determine_state{ #DEPS# (requires that global variable $file1 contains a fil
         if ($opt_d >= 1) { print "$tab"."  MD5 checksum in the checksum-index  : $md5sum_index\n"; }
         if ($md5sum_index =~ /.+/) {
             if (length($md5sum_file) && $md5sum_index !~ $md5sum_file) {
-                $state = $state1; $vstate = $vstate1;                               #  1 = MF = Modified File     - checksum differs from index
-                if (-B "$file1") { $state = $state2; $vstate = $vstate2; }          #  2 = MB = Modified Binary   - you probably replaced the binary file so replace not allowed
+                $state = STATE_MF;                                                  # Modified File     - checksum differs from index
+                if (-B "$file1") { $state = STATE_MB; }                             # Modified Binary   - replaced binary, auto-replace not allowed
             } else {
-                $state = $state3; $vstate = $vstate3;                               #  3 = UF = Unmodified File   - checksum matches with index
-                if (-B "$file1") { $state = $state4; $vstate = $vstate4; }          #  4 = UB = Unmodified Binary - unmodified binary file so replace always allowed
+                $state = STATE_UF;                                                  # Unmodified File   - checksum matches index
+                if (-B "$file1") { $state = STATE_UB; }                             # Unmodified Binary - auto-replace allowed
             }
         } else {
-            $state = $state5; $vstate = $vstate5;                                   #  5 = CF = Custom File       - custom file not installed with portage so replace not allowed
-            if (-B "$file1") { $state = $state6; $vstate = $vstate6; }              #  6 = CB = Custom Binary     - custom binary file so replace not allowed
+            $state = STATE_CF;                                                      # Custom File       - not installed with Portage
+            if (-B "$file1") { $state = STATE_CB; }                                 # Custom Binary
         }
-        if ((-l $file1) && (!-l $file2)) { $state = $state7; $vstate = $vstate7; }  #  7 = LF = Link to File      - replace not allowed, merge
-        if ((!-l $file1) && (-l $file2)) { $state = $state8; $vstate = $vstate8; }  #  8 = FL = File to Link      - replace not allowed, investigate
-        if ((-l $file1) && (-l $file2)) { $state = $state9; $vstate = $vstate9; }   #  9 = LL = Link to Link      - replace not allowed, investigate
+        if ((-l $file1) && (!-l $file2)) { $state = STATE_LF; }                     # Link to File
+        if ((!-l $file1) && (-l $file2)) { $state = STATE_FL; }                     # File to Link
+        if ((-l $file1) && (-l $file2)) { $state = STATE_LL; }                      # Link to Link
     } else {
-        $state = $state0; $vstate = $vstate0;                                       #  0 = ?? = No index found    -> no index checksum-index found
+        $state = STATE_UNKNOWN;                                                     # No checksum.index on disk
     }
+    $vstate = state_label($state);
     if ($opt_d >= 1) { print "$tab"."  State of the current file : $vstate\n"; }
     if (-e $file4) {
         $ancestor_found = "true";
@@ -1092,31 +1110,31 @@ sub list_updates{ #RUNMODE# -l, --list
     for (my $i = 0; $i < @list; ++$i) {
         &prepare_filenames_for_updating($list[$i]);
         &determine_state;
-        if (($enable_stage1 =~ /^yes$|^true$|^on$/i) && (-e $file1) && ($state =~ /^$state3$|^$state4$/)) {
+        if (($enable_stage1 =~ /^yes$|^true$|^on$/i) && (-e $file1) && state_is($state, STATE_UF, STATE_UB)) {
             push(@stage1_queue, $list[$i]);
             $num++; print "$tab"."$num "; if ($num < 1000) { print " "; } if ($num < 100) { print " "; } if ($num < 10)  { print " "; }
             if ($opt_v >= 1) { print "$tab"."Stage[1]  "; }
             print "$tab"."$vstate  $list[$i]\n";
         } else {
-            if (($enable_stage2 =~ /^yes$|^true$|^on$/i) && (-e $file1) && ($state =~ /^$state1$|^$state3$/) && ($ancestor_found =~ "true") && ($merge_conflict =~ "false")) {
+            if (($enable_stage2 =~ /^yes$|^true$|^on$/i) && (-e $file1) && state_is($state, STATE_MF, STATE_UF) && ($ancestor_found =~ "true") && ($merge_conflict =~ "false")) {
                 push(@stage2_queue, $list[$i]);
                 $num++; print "$tab"."$num "; if ($num < 1000) { print " "; } if ($num < 100) { print " "; } if ($num < 10)  { print " "; }
                 if ($opt_v >= 1) { print "$tab"."Stage[2]  "; }
                 print "$tab"."$vstate  $list[$i]\n";
             } else {
-                if (($enable_stage3 =~ /^yes$|^true$|^on$/i) && (-e $file1) && ($state =~ /^$state1$|^$state3$/) && ($ancestor_found =~ "true")) {
+                if (($enable_stage3 =~ /^yes$|^true$|^on$/i) && (-e $file1) && state_is($state, STATE_MF, STATE_UF) && ($ancestor_found =~ "true")) {
                     push(@stage3_queue, $list[$i]);
                     $num++; print "$tab"."$num "; if ($num < 1000) { print " "; } if ($num < 100) { print " "; } if ($num < 10)  { print " "; }
                     if ($opt_v >= 1) { print "$tab"."Stage[3]  "; }
                     print "$tab"."$vstate  $list[$i]\n";
                 } else {
-                    if (($enable_stage4 =~ /^yes$|^true$|^on$/i) && (-e $file1) && ($state =~ /^$state1$|^$state3$|^$state5$/)) {
+                    if (($enable_stage4 =~ /^yes$|^true$|^on$/i) && (-e $file1) && state_is($state, STATE_MF, STATE_UF, STATE_CF)) {
                         push(@stage4_queue, $list[$i]);
                         $num++; print "$tab"."$num "; if ($num < 1000) { print " "; } if ($num < 100) { print " "; } if ($num < 10)  { print " "; }
                         if ($opt_v >= 1) { print "$tab"."Stage[4]  "; }
                         print "$tab"."$vstate  $list[$i]\n";
                     } else {
-                        if (($enable_stage5 =~ /^yes$|^true$|^on$/i) && (($state =~ /^$state2$|^$state4$|^$state6$|^$state7$|^$state8$|^$state9$/) || (!-e $file1))) {
+                        if (($enable_stage5 =~ /^yes$|^true$|^on$/i) && (state_is($state, STATE_MB, STATE_UB, STATE_CB, STATE_LF, STATE_FL, STATE_LL) || (!-e $file1))) {
                             push(@stage5_queue, $list[$i]);
                             $num++; print "$tab"."$num "; if ($num < 1000) { print " "; } if ($num < 100) { print " "; } if ($num < 10)  { print " "; }
                             if ($opt_v >= 1) { print "$tab"."Stage[5]  "; }
@@ -1175,10 +1193,10 @@ sub schedule_automatic_updates{
     for (my $i = 0; $i < @list; ++$i) {
         &prepare_filenames_for_updating($list[$i]);
         &determine_state;
-        if (($enable_stage1 =~ /^yes$|^true$|^on$/i) && (-e $file1) && ($state =~ /^$state3$|^$state4$/)) {
+        if (($enable_stage1 =~ /^yes$|^true$|^on$/i) && (-e $file1) && state_is($state, STATE_UF, STATE_UB)) {
             push(@stage1_queue, $list[$i]);
         } else {
-            if (($enable_stage2 =~ /^yes$|^true$|^on$/i) && (-e $file1) && ($state =~ /^$state1$|^$state3$/) && ($ancestor_found =~ "true") && ($merge_conflict =~ "false")) {
+            if (($enable_stage2 =~ /^yes$|^true$|^on$/i) && (-e $file1) && state_is($state, STATE_MF, STATE_UF) && ($ancestor_found =~ "true") && ($merge_conflict =~ "false")) {
                 push(@stage2_queue, $list[$i]);
             }
         }
@@ -1191,13 +1209,13 @@ sub schedule_manual_updates{
     for (my $i = 0; $i < @list; ++$i) {
         &prepare_filenames_for_updating($list[$i]);
         &determine_state;
-        if (($enable_stage3 =~ /^yes$|^true$|^on$/i) && (-e $file1) && ($state =~ /^$state1$|^$state3$/) && ($ancestor_found =~ "true")) {
+        if (($enable_stage3 =~ /^yes$|^true$|^on$/i) && (-e $file1) && state_is($state, STATE_MF, STATE_UF) && ($ancestor_found =~ "true")) {
             push(@stage3_queue, $list[$i]);
         } else {
-            if (($enable_stage4 =~ /^yes$|^true$|^on$/i) && (-e $file1) && ($state =~ /^$state1$|^$state3$|^$state5$/)) {
+            if (($enable_stage4 =~ /^yes$|^true$|^on$/i) && (-e $file1) && state_is($state, STATE_MF, STATE_UF, STATE_CF)) {
                 push(@stage4_queue, $list[$i]);
             } else {
-                if (($enable_stage5 =~ /^yes$|^true$|^on$/i) && (($state =~ /^$state2$|^$state4$|^$state6$|^$state7$|^$state8$|^$state9$/) || (!-e $file1))) {
+                if (($enable_stage5 =~ /^yes$|^true$|^on$/i) && (state_is($state, STATE_MB, STATE_UB, STATE_CB, STATE_LF, STATE_FL, STATE_LL) || (!-e $file1))) {
                     push(@stage5_queue, $list[$i]);
                 }
             }
@@ -2103,7 +2121,7 @@ sub optimize_backups{ #RUNMODE# --optimize-backups
             print "$tab"."$percentage% - Skip file $file1\n";
             if ($opt_d >= 1) { print "$tab"."[$state] skip  $file1 (exists in repository)\n"; }
         } else {
-            if (($state =~ $state3) || ($state =~ $state4)) {
+            if (state_is($state, STATE_UF, STATE_UB)) {
                 $path = dirname($file2);
                 if (!-e "$path") {
                     if ($percentage < 100) { print " "; } if ($percentage < 10)  { print " "; }
@@ -2268,46 +2286,46 @@ sub warn_sshfs_deprecated {
 sub show_warning{
     if ($opt_d >= 1) { print "$tab"."<show_warning>\n"; $tab = $tab."    "; }
 # 80 chars            ________________________________________________________________________________
-    if ($state =~ /^$state0$/) {
+    if (state_is($state, STATE_UNKNOWN)) {
         print "$tab"."* YOU SHOULD CHOOSE [y] TO UPDATE MANUALLY! CFG-UPDATE CANNOT\n";
         print "$tab"."* DETERMINE IF IT IS SAFE TO REPLACE THIS FILE WITH THE NEW VERSION.\n";
     }
-    if ($state =~ /^$state1$/) {
+    if (state_is($state, STATE_MF)) {
         print "$tab"."* YOU ARE ABOUT TO UPDATE A MODIFIED FILE WHICH PROBABLY CONTAINS\n";
         print "$tab"."* CUSTOM SETTINGS. YOU ARE FORCED TO UPDATE MANUALLY!\n";
     }
-    if ($state =~ /^$state2$/) {
+    if (state_is($state, STATE_MB)) {
         print "$tab"."* YOU ARE ABOUT TO UPDATE A MODIFIED BINARY. YOU SHOULD ASK YOURSELF\n";
         print "$tab"."* WHO CHANGED IT AND WHY? WHAT DOES IT DO? THIS FILE COULD EVEN BE\n";
         print "$tab"."* REPLACED BY A VIRUS OR ROOTKIT! YOU SHOULD INVESTIGATE THIS...\n";
         print "$tab"."* IGNORE THIS WARNING IF YOU RETRY UPDATING AFTER RESTORING A BACKUP!\n";
     }
-    if ($state =~ /^$state3$/) {
+    if (state_is($state, STATE_UF)) {
         print "$tab"."* YOU CAN SAFELY REPLACE THIS UNMODIFIED FILE WITH THE NEW VERSION.\n";
     }
-    if ($state =~ /^$state4$/) {
+    if (state_is($state, STATE_UB)) {
         print "$tab"."* YOU CAN SAFELY REPLACE THIS UNMODIFIED BINARY WITH THE NEW VERSION.\n";
     }
-    if ($state =~ /^$state5$/) {
+    if (state_is($state, STATE_CF)) {
         print "$tab"."* YOU ARE ABOUT TO UPDATE A CUSTOM FILE. YOU SHOULD ASK YOURSELF\n";
         print "$tab"."* WHERE DOES IT COME FROM AND WHAT HAPPENDS WHEN YOU REPLACE IT?\n";
         print "$tab"."* PORTAGE DID NOT INSTALL THE CURRENT FILE, MOST LIKELY IT HAS BEEN\n";
         print "$tab"."* CREATED AFTER INSTALLATION AND IT MAY CONTAIN CUSTOM SETTINGS.\n";
     }
-    if ($state =~ /^$state6$/) {
+    if (state_is($state, STATE_CB)) {
         print "$tab"."* YOU ARE ABOUT TO UPDATE A CUSTOM BINARY. YOU SHOULD ASK YOURSELF\n";
         print "$tab"."* WHERE DOES IT COME FROM AND WHAT HAPPENDS WHEN YOU REPLACE IT?\n";
         print "$tab"."* PORTAGE DID NOT INSTALL THE CURRENT BINARY.\n";
     }
-    if ($state =~ /^$state7$/) {
+    if (state_is($state, STATE_LF)) {
         print "$tab"."* OPTIONALLY REPLACE A LINK WITH A FILE. YOU BETTER CHECK BOTH THE\n";
         print "$tab"."* LINK AND THE FILE FIRST. THIS USUALLY MEANS BASELAYOUT CHANGES.\n";
     }
-    if ($state =~ /^$state8$/) {
+    if (state_is($state, STATE_FL)) {
         print "$tab"."* OPTIONALLY REPLACE A FILE WITH A LINK. YOU BETTER CHECK BOTH THE\n";
         print "$tab"."* FILE AND THE LINK FIRST. THIS USUALLY MEANS BASELAYOUT CHANGES.\n";
     }
-    if ($state =~ /^$state9$/) {
+    if (state_is($state, STATE_LL)) {
         print "$tab"."* OPTIONALLY REPLACE A LINK WITH A LINK. YOU BETTER CHECK BOTH LINKS\n";
         print "$tab"."* FIRST. THIS USUALLY MEANS BASELAYOUT CHANGES.\n";
     }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -134,7 +134,7 @@ Recursively scans `CONFIG_PROTECT` directories for files matching `._cfg????_*` 
 
 ### State classification (`determine_state`)
 
-Compares the live file, the `._cfg*` update, and the checksum index:
+Compares the live file, the `._cfg*` update, and the checksum index. Code uses `STATE_*` constants (e.g. `STATE_MF`) with human-readable labels from `%STATE_DESC`:
 
 | Code | Meaning | Typical stages |
 |------|---------|------------------|

--- a/test/README.md
+++ b/test/README.md
@@ -18,6 +18,7 @@ Combine all scenarios with [`fixtures/checksum.index.seed`](fixtures/checksum.in
 
 | Directory | State | Stage | Summary |
 |-----------|-------|-------|---------|
+| [`stage0-no-index`](fixtures/stage0-no-index/) | `--` | — | No `checksum.index` on disk; unknown state (Tier A only, not in combined sandbox) |
 | [`stage1-unmodified-text`](fixtures/stage1-unmodified-text/) | UF | 1 | Live file matches index MD5; auto-replace |
 | [`stage1-unmodified-binary`](fixtures/stage1-unmodified-binary/) | UB | 1 | Unmodified binary; auto-replace |
 | [`stage2-3way-merge-success`](fixtures/stage2-3way-merge-success/) | MF | 2 | Modified file + ancestor backup; diff3 merges cleanly |
@@ -56,7 +57,7 @@ FEATURES=test USE=test emerge --oneshot app-portage/cfg-update
 | Tier | What | Checks |
 |------|------|--------|
 | 0 | static + lint | `perl -c`, `bash -n`, optional `shellcheck`, `lint-fixtures.sh` |
-| A | `-lv`, `-s` | Combined + per-scenario classify (12 markers), protected dirs, ancestor backups on disk |
+| A | `-lv`, `-s` | Combined + per-scenario classify (12 markers), missing-index case, protected dirs, ancestor backups on disk |
 | B | `-p -au` | Stages 1–2 pretend; live files unchanged |
 | C | `-au` | Stages 1–2 execute: golden file equality, binary MD5, 3-way conflict handling, stage 3 re-list |
 | D | `-u` + stdin | Stages 3–5 execute (one stage enabled at a time): stage-specific output, mock 3-way merge, replace/keep filesystem outcomes |

--- a/test/fixtures/stage0-no-index/checksum.index.entry
+++ b/test/fixtures/stage0-no-index/checksum.index.entry
@@ -1,0 +1,1 @@
+# not indexed — no checksum.index file deployed (unknown state)

--- a/test/fixtures/stage0-no-index/etc/._cfg0000_test_no_index_file
+++ b/test/fixtures/stage0-no-index/etc/._cfg0000_test_no_index_file
@@ -1,0 +1,3 @@
+#version 1.1
+
+SETTING = default # contains a default value chosen by the developer

--- a/test/fixtures/stage0-no-index/etc/test_no_index_file
+++ b/test/fixtures/stage0-no-index/etc/test_no_index_file
@@ -1,0 +1,3 @@
+#version 1.0
+
+SETTING = default # contains a default value chosen by the developer

--- a/test/fixtures/stage0-no-index/scenario.md
+++ b/test/fixtures/stage0-no-index/scenario.md
@@ -1,0 +1,21 @@
+# Stage 0 — missing checksum index (unknown state)
+
+**Expected state:** `--` (No index found)  
+**Expected stage:** none — marker is not routed when the index file is absent
+
+## Situation
+
+A `._cfg0000_*` marker exists but `checksum.index` is not present on disk. In harness mode (`--ebuild --testsandbox`), cfg-update does not exit early; `determine_state` classifies the live file as unknown. Normal `-lv` output does not list the marker (no stage queue matches `--`).
+
+## Files
+
+| File | Role |
+|------|------|
+| `etc/test_no_index_file` | Live config |
+| `etc/._cfg0000_test_no_index_file` | Pending update marker |
+
+## Expected behavior
+
+- `cfg-update -d -lv` → debug shows `State of the current file : No index found`
+- `cfg-update -lv` → marker not listed under any `Stage[N]`
+- `cfg-update -au` → `<< Stage1 >> … not found, skipping`

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -195,6 +195,7 @@ EOF
     if [[ "$mode" == "all" ]]; then
         for scenario in "$FIXTURES"/stage*/; do
             [[ -d "$scenario/etc" ]] || continue
+            [[ "$(basename "$scenario")" == "stage0-no-index" ]] && continue
             cp -a "$scenario/etc/." "$SANDBOX/etc/test/"
             deploy_backups "$scenario"
         done
@@ -221,6 +222,14 @@ EOF
         "$SANDBOX/var/lib/cfg-update/backups" \
         "$stages" \
         "$merge_tool"
+}
+
+setup_sandbox_no_index() {
+    local scenario="${1:-stage0-no-index}"
+    setup_sandbox "$scenario"
+    rm -f "$SANDBOX/var/lib/cfg-update/checksum.index"
+    assert_missing "no-index sandbox removed checksum.index" \
+        "$SANDBOX/var/lib/cfg-update/checksum.index"
 }
 
 run_cfg_update() {
@@ -559,6 +568,23 @@ tier_a_per_scenario() {
         'Stage\[5\][[:space:]]+Link to Link[[:space:]].*_cfg0000_test_link_2_link' "$output"
 }
 
+tier_a_no_index() {
+    echo "=== Tier A: missing checksum index (no-index) ==="
+    local output
+
+    setup_sandbox_no_index stage0-no-index
+    output="$(run_cfg_update -d -lv 2>&1)" || true
+    assert_output_matches "no-index: debug shows unknown state" \
+        'State of the current file : No index found' "$output"
+    assert_output_not_matches "no-index: marker not routed to any stage" \
+        'Stage\[[1-5]\][[:space:]].*_cfg0000_test_no_index_file' "$output"
+
+    setup_sandbox_no_index stage0-no-index
+    output="$(run_cfg_update -au 2>&1)" || true
+    assert_output_matches "no-index: stage1 skips when index absent" \
+        '<< Stage1 >>.*not found, skipping' "$output"
+}
+
 tier_a_protected_dirs() {
     echo "=== Tier A: protected dirs (-s) ==="
     setup_sandbox all
@@ -844,6 +870,7 @@ main() {
     tier0_lint_fixtures
     tier_a_classify_combined
     tier_a_per_scenario
+    tier_a_no_index
     tier_a_protected_dirs
     tier_a_ancestor_backups
     tier_b_pretend_auto


### PR DESCRIPTION
test: add missing checksum.index Tier A coverage (issue #16)

Add stage0-no-index fixture and tier_a_no_index harness checks for the unknown-state path when checksum.index is absent. Exclude the fixture from the combined sandbox so the 12-marker suite stays unchanged.