### PR TITLE
Remove undocumented --test stub (issue #27)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,11 @@
 # Copyright 2002-2005 Gentoo Technologies, Inc.; Distributed under the GPL v2
 # $Header: $
 
+*cfg-update-1.10.0 (development)
+
+  Remove undocumented --test runmode and test_code stub; use test/run-tests.sh
+  instead (issue #27).
+
 *cfg-update-1.8.2-r1 (18 MAY 2007)
 
   18 MAY 2007; S. van Boven <sboven@zeelandnet.nl> cfg-update

--- a/cfg-update
+++ b/cfg-update
@@ -207,7 +207,6 @@ $Term::ANSIColor::AUTORESET = 1;
     my $opt_ebuild = 0;
     my $opt_testsandbox = 0;
     my $opt_paludis = 0;
-    my $opt_test_code = 0;
     my $opt_move_backups = 0;
 #    my $opt_enable_portage_hook = 0;
 #    my $opt_enable_paludis_hook = 0;
@@ -235,7 +234,6 @@ $Term::ANSIColor::AUTORESET = 1;
         GetOptions ('paludis+'                 => \$opt_paludis);
         GetOptions ('ebuild+'                  => \$opt_ebuild);
         GetOptions ('testsandbox+'             => \$opt_testsandbox);
-        GetOptions ('test+'                    => \$opt_test_code);
         GetOptions ('move-backups+'            => \$opt_move_backups);
         GetOptions ('optimize-backups+'        => \$opt_optimize_backups);
     }
@@ -317,14 +315,13 @@ $Term::ANSIColor::AUTORESET = 1;
 
 # Reject unrecognized options left in @ARGV when a runmode flag is also present (Getopt pass_through).
     if (@ARGV > 0) {
-        my $runmode = ($opt_test_code > 0 || $opt_help > 0 || $opt_s > 0 || $opt_l > 0 || $opt_u > 0 ||
+        my $runmode = ($opt_help > 0 || $opt_s > 0 || $opt_l > 0 || $opt_u > 0 ||
                        $opt_b > 0 || $opt_r > 0 || $opt_disable_portage_hook > 0 || $opt_disable_paludis_hook > 0 ||
                        $opt_move_backups > 0 || $opt_optimize_backups > 0);
         if ($runmode) { &print_usage; exit; }
     }
 
 # Go to runmode subroutine (optionally preceeded by checks) if a corresponding argument is found. Exit when done...
-    if ($opt_test_code > 0)            { &test_code; exit; }
     if ($opt_help > 0)                 { &print_usage; exit; }
     if ($opt_s > 0)                    { &list_dirs; exit;}
     if ($opt_l > 0)                    { &list_updates; exit;}
@@ -348,11 +345,6 @@ $Term::ANSIColor::AUTORESET = 1;
 ######################################################################################################################
 #                                     ALL SUBROUTINES BELOW THIS LINE                                                #
 ######################################################################################################################
-
-sub test_code{ #RUNMODE# --test
-# Add your test code here and run "cfg-update --test" to execute it...
-    print "Nothing to test...\n";
-}
 
 sub state_is { #ARGS# ($state, @codes)
     my ($s, @codes) = @_;
@@ -2199,7 +2191,6 @@ sub show_debug_info {
         print "$tab"."opt_v = $opt_v\n";
         print "$tab"."opt_t = $opt_t\n";
         print "$tab"."opt_help                 = $opt_help\n";
-        print "$tab"."opt_test_code            = $opt_test_code\n";
         print "$tab"."opt_ebuild               = $opt_ebuild\n";
         print "$tab"."opt_testsandbox          = $opt_testsandbox\n";
         print "$tab"."opt_move_backups         = $opt_move_backups\n";

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,7 @@ This document describes how `cfg-update` works internally. For a file-by-file in
 
 ## Overview
 
-`cfg-update` is a single Perl script (~2,500 lines, 54 subroutines) that:
+`cfg-update` is a single Perl script (~2,500 lines, 53 subroutines) that:
 
 1. Maintains a **checksum index** of files in `CONFIG_PROTECT` directories
 2. Scans for Portage config update markers (`._cfg????_*`)
@@ -234,4 +234,4 @@ These enable stage 2's 3-way merges on subsequent updates.
 
 ## Testing
 
-`test.tgz` contains synthetic `._cfg*` scenarios (unmodified files, 3-way merge success/conflict, binaries, symlinks). The `prepare_cfg-update_test` script seeds a checksum index and runs `cfg-update --list`. These fixtures will be extracted into the repo and wired into CI in a later stage.
+Integration tests live under [`test/`](../test/). Per-scenario fixtures are in [`test/fixtures/`](../test/fixtures/); the harness is [`test/run-tests.sh`](../test/run-tests.sh) (see [`test/README.md`](../test/README.md)). Run `./test/run-tests.sh` from the repo root (no root required); use `--full` for ebuild/CI parity. The ebuild `src_test()` invokes the same harness when `USE=test`.

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -90,14 +90,14 @@ Every normal invocation (unless `--ebuild`) runs `check_hooks` and `check_tool` 
 | `--disable-portage-hook` | `disable_portage_hook` | Yes | Medium (uninstall) |
 | `--disable-paludis-hook` | `disable_paludis_hook` | Yes | Low |
 | `--ebuild` | Suppresses hooks/tool check | — | Internal (ebuild install) |
-| `--test` | `test_code` (empty stub) | No | Remove or repurpose |
+| `--testsandbox` | Bypass `root_only` with `--ebuild` | — | Internal (test harness) |
 | `--help` | `print_usage` | No | **High** |
 | `file1 file2` | `diff_two_files` | Yes | Low |
 | `file1 file2 file3` | `diff_three_files` | Yes | Low |
 
 ---
 
-## Subroutine inventory (54 total)
+## Subroutine inventory (53 total)
 
 ### Core update pipeline (keep)
 
@@ -158,7 +158,7 @@ Every normal invocation (unless `--ebuild`) runs `check_hooks` and `check_tool` 
 | Subroutine / artifact | Evidence | Recommendation |
 |-----------------------|----------|----------------|
 | ~~`breakpoint`~~ | Zero call sites | **Removed** (stage 3) |
-| `test_code` (L435) | Stub prints "Nothing to test..."; only called by `--test` | **Repurpose** for smoke tests in stage 6, or remove flag |
+| ~~`test_code` / `--test`~~ | Empty stub; superseded by `test/run-tests.sh` | **Removed** (issue #27) |
 | ~~emerge wrappers / phphelper~~ | Superseded by Portage bashrc hook | **Removed** (stage 3) |
 | Stale hook/merge messages in `cfg-update` | xxdiff defaults, "alias" wording | **Fixed** (stage 3) |
 
@@ -326,9 +326,8 @@ Each scenario has `etc/` (live + `._cfg*` files), optional `backups/etc/test/` (
 | ~~sshfs multi-host (`-h`, `--mount`)~~ | — | Removed (1.10.0); HOWTO at git tag 1.9.0 |
 | ~~emerge wrapper scripts~~ | — | Removed (stage 3) |
 | ~~PHP helper~~ | — | Removed (stage 3) |
-| `--test` stub | **Repurpose** | Hook for automated smoke tests (stage 6) |
+| ~~`--test` stub / `test_code`~~ | — | Removed (issue #27); use `test/run-tests.sh` |
 | ~~`breakpoint` subroutine~~ | — | Removed (stage 3) |
-| `test_code` empty stub | **Repurpose/remove** | No value today |
 
 ---
 

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -456,6 +456,11 @@ tier0_static() {
     else
         fail "perl -c cfg-update"
     fi
+    if perl "$CFG_UPDATE" --test 2>&1 | grep -q "Nothing to test"; then
+        fail "--test stub still present"
+    else
+        pass "--test stub removed"
+    fi
     if bash -n "$REPO_ROOT/test/run-tests.sh"; then
         pass "bash -n run-tests.sh"
     else


### PR DESCRIPTION
Delete the dead --test runmode and test_code subroutine now that test/run-tests.sh is the canonical integration harness. Add a Tier 0 regression check, update docs, and record the change in ChangeLog.