### PR TITLE
Prune niche/debug features for 1.10.1 (issue #28)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,12 @@
 # Copyright 2002-2005 Gentoo Technologies, Inc.; Distributed under the GPL v2
 # $Header: $
 
+*cfg-update-1.10.1 (development)
+
+  Prune niche/debug features: -s/--show-protected-dirs, ad-hoc diff modes,
+  --move-backups, dead commented code, and unused log_file/merge_history
+  (issue #28). Do not tag until approved.
+
 *cfg-update-1.10.0 (development)
 
   Remove undocumented --test runmode and test_code stub; use test/run-tests.sh

--- a/cfg-update
+++ b/cfg-update
@@ -31,15 +31,11 @@ $Term::ANSIColor::AUTORESET = 1;
 #
 
 ######################################################################################################################
-#                                          TODO_LIST                                                                 #
-######################################################################################################################
-
-######################################################################################################################
 #                                          GLOBAL VARIABLES AND SETTINGS                                             #
 ######################################################################################################################
 
 # Setting program variables...
-    my $version           = "1.10.0";
+    my $version           = "1.10.1";
     my $progname          = basename($0);
     my $debug             = "2>/dev/null";
     my $website           = "http://people.zeelandnet.nl/xentric";
@@ -58,7 +54,6 @@ $Term::ANSIColor::AUTORESET = 1;
     my $backup_path       = "/var/lib/cfg-update/backups";
     my $index_file        = "/var/lib/cfg-update/checksum.index";
     my $settings          = "/etc/cfg-update.conf";
-    my $log_file          = "/var/lib/cfg-update/cfg-update.log";
     $settings   = $ENV{CFG_UPDATE_CONF}  if defined $ENV{CFG_UPDATE_CONF}  && $ENV{CFG_UPDATE_CONF}  ne "";
     my $enable_backups    = "yes";
     my $enable_stage1     = "yes";
@@ -97,8 +92,6 @@ $Term::ANSIColor::AUTORESET = 1;
         if ($line =~ /^\s*INSTALL_LOG\s*=\s*/i)       { $install_log = &strip($'); $install_log_configured = 1; }
         if ($line =~ /^\s*PORTAGE_HOOK\s*=\s*/i)      { $portage_hook      = &strip($'); }
         if ($line =~ /^\s*PALUDIS_HOOK\s*=\s*/i)      { $paludis_hook      = &strip($'); }
-        if ($line =~ /^\s*LOGFILE\s*=\s*/i)           { $log_file          = &strip($'); }
-        if ($line =~ /^\s*LOG_FILE\s*=\s*/i)          { $log_file          = &strip($'); }
         if ($line =~ /^\s*ROOTDIR\s*=\s*/i)           { $rootdir           = &strip($'); }
         if ($line =~ /^\s*XXDIFF_STYLE\s*=\s*/i)      { $xxdiff_style      = &strip($'); }
         if ($line =~ /^\s*CONFIG_NEW\s*=\s*/i)        { $config_new        = &strip($'); }
@@ -113,8 +106,6 @@ $Term::ANSIColor::AUTORESET = 1;
         if ($line =~ /^\s*MERGED\s*=\s*/i)            { $merged            = &strip($'); }
     }
     close(FILE);
-# Check for trailing slash on backup_path...
-    if ($backup_path =~ /\/$/) { chop($backup_path); }   # remove trailing slash if found
 # Check for trailing slash on backup_path...
     if ($backup_path =~ /\/$/) { chop($backup_path); }   # remove trailing slash if found
 # Check if backup_path exists...
@@ -138,7 +129,6 @@ $Term::ANSIColor::AUTORESET = 1;
         'FL' => 'File to Link     ',
         'LL' => 'Link to Link     ',
     );
-###    my $indexing_complete = "undefined";
     my $md5sum;
     my $md5sum_file;
     my $md5sum_index;
@@ -163,7 +153,6 @@ $Term::ANSIColor::AUTORESET = 1;
     my @stage3_queue;
     my @stage4_queue;
     my @stage5_queue;
-    my @merge_history;
     my $input;
     my $key;
     my $num;
@@ -192,7 +181,6 @@ $Term::ANSIColor::AUTORESET = 1;
 # Set variables for commandline arguments...
     my $opt_i = 0;
     my $opt_f = 0;
-    my $opt_s = 0;
     my $opt_l = 0;
     my $opt_u = 0;
     my $opt_b = 0;
@@ -207,9 +195,6 @@ $Term::ANSIColor::AUTORESET = 1;
     my $opt_ebuild = 0;
     my $opt_testsandbox = 0;
     my $opt_paludis = 0;
-    my $opt_move_backups = 0;
-#    my $opt_enable_portage_hook = 0;
-#    my $opt_enable_paludis_hook = 0;
     my $opt_disable_portage_hook = 0;
     my $opt_disable_paludis_hook = 0;
     my $opt_optimize_backups = 0;
@@ -217,7 +202,6 @@ $Term::ANSIColor::AUTORESET = 1;
     for (my $j = 0; $j < 25; ++$j) {
         GetOptions ('f|force+'                 => \$opt_f);
         GetOptions ('i|index+'                 => \$opt_i);
-        GetOptions ('s|show-protected-dirs+'   => \$opt_s);
         GetOptions ('l|list+'                  => \$opt_l);
         GetOptions ('u|update+'                => \$opt_u);
         GetOptions ('b|backups+'               => \$opt_b);
@@ -234,7 +218,6 @@ $Term::ANSIColor::AUTORESET = 1;
         GetOptions ('paludis+'                 => \$opt_paludis);
         GetOptions ('ebuild+'                  => \$opt_ebuild);
         GetOptions ('testsandbox+'             => \$opt_testsandbox);
-        GetOptions ('move-backups+'            => \$opt_move_backups);
         GetOptions ('optimize-backups+'        => \$opt_optimize_backups);
     }
 # Update the mergetool and mergetoolname variable with optional commandline argument -t...
@@ -315,26 +298,21 @@ $Term::ANSIColor::AUTORESET = 1;
 
 # Reject unrecognized options left in @ARGV when a runmode flag is also present (Getopt pass_through).
     if (@ARGV > 0) {
-        my $runmode = ($opt_help > 0 || $opt_s > 0 || $opt_l > 0 || $opt_u > 0 ||
+        my $runmode = ($opt_help > 0 || $opt_l > 0 || $opt_u > 0 ||
                        $opt_b > 0 || $opt_r > 0 || $opt_disable_portage_hook > 0 || $opt_disable_paludis_hook > 0 ||
-                       $opt_move_backups > 0 || $opt_optimize_backups > 0);
+                       $opt_optimize_backups > 0);
         if ($runmode) { &print_usage; exit; }
     }
 
 # Go to runmode subroutine (optionally preceeded by checks) if a corresponding argument is found. Exit when done...
     if ($opt_help > 0)                 { &print_usage; exit; }
-    if ($opt_s > 0)                    { &list_dirs; exit;}
     if ($opt_l > 0)                    { &list_updates; exit;}
     if ($opt_u > 0)                    { &root_only unless &sandbox_mode; &update_files; exit; }
     if ($opt_b > 0)                    { &list_backups; exit; }
     if ($opt_r > 0)                    { &root_only unless &sandbox_mode; &restore_backups($opt_r); exit; }
     if ($opt_disable_portage_hook > 0) { &root_only; &disable_portage_hook; exit; }
     if ($opt_disable_paludis_hook > 0) { &root_only; &disable_paludis_hook; exit; }
-    if ($opt_move_backups > 0)         { &root_only unless &sandbox_mode; &move_backups; exit; }
     if ($opt_optimize_backups > 0)     { &root_only unless &sandbox_mode; &optimize_backups; exit; }
-# If none of the above options are used, check for undocumented usage modes (2-way and 3-way diff mode)
-    if ((@ARGV == 2) && (-f $ARGV[0]) && (-f $ARGV[1]))                  { &root_only; &diff_two_files; exit;   } # Simply parsing two files to diff/merge tool
-    if ((@ARGV == 3) && (-f $ARGV[0]) && (-f $ARGV[1]) && (-f $ARGV[2])) { &root_only; &diff_three_files; exit; } # Simply parsing three files to diff/merge tool
 # Show help screen when invalid options are used...
     if ((@ARGV > 1) || ($opt_t !~ /^novalue$/)) { &print_usage; exit; }
 # Exit when there's nothing left to do...
@@ -641,24 +619,6 @@ sub launch_tool{ #ARGS# ("pretend|execute","mergetool")
         system("$cmd");                                                 # launch the tool
     }
     if ($opt_d >= 1) { $tab =~ s/    //; print "$tab"."</launch_tool>\n"; }
-}
-
-sub list_dirs{ #RUNMODE# -s, --show-dirs
-    if ($opt_d >= 1) { print "$tab"."<list_dirs>\n"; $tab = $tab."    "; }
-    &find_protected_dirs;
-    print "$tab"."\n";
-    print "$tab"."These (localhost) directories are protected with CONFIG_PROTECT:\n";
-    for (my $i = 0; $i < @dir; ++$i) {
-        print "$tab"."$dir[$i]\n";
-    }
-    &find_masked_dirs;
-    print "$tab"."\n";
-    print "$tab"."These (localhost) directories are excluded with CONFIG_PROTECT_MASK:\n";
-    for (my $i = 0; $i < @maskdir; ++$i) {
-        print "$tab"."$maskdir[$i]\n";
-    }
-    print "$tab"."\n";
-    if ($opt_d >= 1) { $tab =~ s/    //; print "$tab"."</list_dirs>\n"; }
 }
 
 sub find_protected_dirs{
@@ -1505,17 +1465,12 @@ sub update_merge_complete{ #ARGS# ("pretend|execute")
     if (($opt_v >= 1) || ($opt_d >= 1)) { if ($executable =~ "yes") { print "$tab"."  chmod +x $file1\n"; }}
     if ($_[0] =~ /execute/) { if ($executable =~ "yes") { `chmod +x "$file1" $debug`; }}
     print BOLD GREEN "$tab"."Update complete...\n\n";
-#    my $merge_action = "$file1;$md5sum_before::$file2;$md5sum_update=>$file1;$md5sum_after";
-#    print "$tab"."$merge_action\n";
-#    push(@merge_history, $merge_action);
-#    `echo $merge_action >> $log_file`;
     if ($opt_d >= 1) { $tab =~ s/    //; print "$tab"."</update_merge_complete>\n"; }
 }
 
 sub update_replace_complete{ #ARGS# ("pretend|execute")
     # using copy A B followed by remove A instead of move A B because the move command doesn't handle links properly
     if ($opt_d >= 1) { print "$tab"."<update_replace_complete>\n"; $tab = $tab."    "; }
-#    print "$tab"."  Replacing current config file with $file2\n";
     print "$tab"."  Replacing it with $file2\n";
     if (-l $file1) {
         if (($opt_v >= 1) || ($opt_d >= 1)) { print "$tab"."  rm -f \"$file1\"\n"; }
@@ -1538,10 +1493,6 @@ sub update_replace_complete{ #ARGS# ("pretend|execute")
     if (($opt_v >= 1) || ($opt_d >= 1)) { if ($executable =~ "yes") { print "$tab"."  chmod +x $file1\n"; }}
     if ($_[0] =~ /execute/) { if ($executable =~ "yes") { `chmod +x "$file1" $debug`; }}
     print BOLD GREEN "$tab"."Update complete...\n\n";
-#    my $merge_action = "$file1;$md5sum_before::$file2;$md5sum_update=>$file1;$md5sum_after";
-#    print "$tab"."$merge_action\n";
-#    push(@merge_history, $merge_action);
-#    `echo $merge_action >> $log_file`;
     if ($opt_d >= 1) { $tab =~ s/    //; print "$tab"."</update_replace_complete>\n"; }
 }
 
@@ -1563,10 +1514,6 @@ sub update_keep_complete{ #ARGS# ("pretend|execute")
     if (($opt_v >= 1) || ($opt_d >= 1)) { if ($executable =~ "yes") { print "$tab"."  chmod +x $file1\n"; }}
     if ($_[0] =~ /execute/) { if ($executable =~ "yes") { `chmod +x "$file1" $debug`; }}
     print BOLD GREEN "$tab"."Update complete...\n\n";
-#    my $merge_action = "$file1;$md5sum_before::$file2;$md5sum_update=>$file1;$md5sum_after";
-#    print "$tab"."$merge_action\n";
-#    push(@merge_history, $merge_action);
-#    `echo $merge_action >> $log_file`;
     if ($opt_d >= 1) { $tab =~ s/    //; print "$tab"."</update_keep_complete>\n"; }
 }
 
@@ -1748,53 +1695,6 @@ sub restore_backups{ #RUNMODE# -r, --restore
     if ($opt_d >= 1) { $tab =~ s/    //; print "$tab"."</restore_backups>\n"; }
 }
 
-sub move_backups{ #RUNMODE# --move-backups
-    if ($opt_d >= 1) { print "$tab"."<move_backups>\n"; $tab = $tab."    "; }
-# Move all existing ._old-cfg_* and ._new-cfg_* files to the backup_path (if backup_path is not empty)
-    if ($backup_path =~ /^$/) {
-        print "$tab"."   If you want to move your backups to a separate directory you should\n";
-        print "$tab"."   set the variable BACKUP_PATH in $settings\n";
-        print "$tab"."   $progname --move-backups will move your backups to this directory.\n";
-    } else {
-        &find_protected_dirs;
-        @list = ();
-        for (my $i = 0; $i < @dir; ++$i) {
-            if ($opt_d >= 1) { print "$tab"."  find $dir[$i] -name '._new-cfg_*' -or -name '._old-cfg_*' $debug | sort $debug\n"; }
-            push(@list, `find $dir[$i] -name '._new-cfg_*' -or -name '._old-cfg_*' $debug | sort $debug`);
-        }
-        chomp @list;
-        if (@list == 0) {
-            print "$tab"."   No backup files found in the protected directories...\n";
-            if ($enable_backups =~ /^yes$|^true$|^on$/i) {
-                print "$tab"."   Backups are currently being saved to $backup_path\n";
-            } else {
-                print "$tab"."   Backups are disabled in $settings\n";
-            }
-        } else {
-            $totalcount = @list;
-            for (my $i = 0; $i < @list; $i++) {
-                $num = $i + 1;
-                $path = dirname($list[$i]);
-                $path = $path."/";
-                $file = basename($list[$i]);
-                $file1 = $path.$file;                   # /path/._new-cfg_file or /path/._old-cfg_file (source)
-                $file2 = $backup_path.$path.$file;      # /backup_path/path/._new-cfg_file (destination)
-                $path = dirname($file2);
-                my $percentage = int($num/$totalcount*100);
-                if (!-e "$path") {
-                    if ($opt_d >= 1) { print "$tab"."mkdir -p $path\n"; }
-                    `mkdir -p $path`;
-                }
-                if ($percentage < 100) { print " "; } if ($percentage < 10)  { print " "; }
-                print "$tab"."$percentage% - Moving backup to $file2\n";
-                if ($opt_d >= 1) { print "$tab"."mv $file1 $file2\n"; }
-                `mv "$file1" "$file2"`;
-            }
-        }
-    }
-    if ($opt_d >= 1) { $tab =~ s/    //; print "$tab"."</move_backups>\n"; }
-}
-
 sub optimize_backups{ #RUNMODE# --optimize-backups
     if ($opt_d >= 1) { print "$tab"."<optimize_backups>\n"; $tab = $tab."    "; }
 # Create fake backups of the previous ._cfg0000_ file to maximize chances for automatic updating
@@ -1877,33 +1777,6 @@ sub disable_paludis_hook { #RUNMODE# --disable-paludis-hook
         if ($opt_ebuild == 0) { print "$tab"."Paludis hook $paludis_hook\nDoes not exist, nothing to disable...\n"; }
     }
     if ($opt_d >= 1) { $tab =~ s/    //; print "$tab"."</disable_paludis_hook>\n"; }
-}
-
-sub diff_two_files { #RUNMODE# when the two arguments are both existing files
-    $file1 = $ARGV[0];                                                        # contains /etc/foo             (current)
-    $file2 = $ARGV[1];                                                        # contains /etc/._cfg0000_foo   (update)
-    $path = dirname($ARGV[0]);
-    $file = basename($ARGV[0]);
-    $file5 = $merged;
-    $file5 =~ s/\*/$file/;
-    $file5 = $path."/".$file5;                                             # contains /etc/foo.merge       (merged result)
-    $threeway_update = "no";
-    &launch_tool("execute",$merge_tool);
-    if (-s "$file5") { print "$tab"."Merged output has been saved as $file5\n"; }
-}
-
-sub diff_three_files { #RUNMODE# when the three arguments are all existing files
-    $file1 = $ARGV[0];                                                        # contains /etc/foo             (current)
-    $file4 = $ARGV[1];                                                        # contains /etc/._ancestor_foo  (ancestor)
-    $file2 = $ARGV[2];                                                        # contains /etc/._cfg0000_foo   (update)
-    $path = dirname($ARGV[0]);
-    $file = basename($ARGV[0]);
-    $file5 = $merged;
-    $file5 =~ s/\*/$file/;
-    $file5 = $path."/".$file5;                                             # contains /etc/foo.merge       (merged result)
-    $threeway_update = "yes";
-    &launch_tool("execute",$merge_tool);
-    if (-s "$file5") { print "$tab"."Merged output has been saved as $file5\n"; }
 }
 
 sub tool_intro{ #ARGS# ("mergetoolname")
@@ -2088,10 +1961,6 @@ sub print_usage{ #RUNMODE# -?, --help (or when no arguments or when unusable arg
         print "$tab"."          The Portage hook will execute: $progname --index\n";
         print "$tab"."          The Paludis hook will execute: $progname --index --paludis\n";
         print "$tab"."\n";
-        print "$tab"."  -s, --show-protected-dirs\n";
-        print "$tab"."          Shows directories protected by the CONFIG_PROTECT system variable\n";
-        print "$tab"."          $progname searches for updates in the CONFIG_PROTECT directories\n";
-        print "$tab"."\n";
         print "$tab"."  --optimize-backups\n";
         print "$tab"."          Backups can be used for automatic 3-way merging. This option creates\n";
         print "$tab"."          extra backups to maximize the chances of future automatic updates\n";
@@ -2179,7 +2048,6 @@ sub show_debug_info {
         print "$tab"."merged            = $merged\n";
         print "$tab"."opt_i = $opt_i\n";
         print "$tab"."opt_f = $opt_f\n";
-        print "$tab"."opt_s = $opt_s\n";
         print "$tab"."opt_l = $opt_l\n";
         print "$tab"."opt_u = $opt_u\n";
         print "$tab"."opt_b = $opt_b\n";
@@ -2193,7 +2061,6 @@ sub show_debug_info {
         print "$tab"."opt_help                 = $opt_help\n";
         print "$tab"."opt_ebuild               = $opt_ebuild\n";
         print "$tab"."opt_testsandbox          = $opt_testsandbox\n";
-        print "$tab"."opt_move_backups         = $opt_move_backups\n";
         print "$tab"."opt_disable_portage_hook = $opt_disable_portage_hook\n";
         print "$tab"."opt_disable_paludis_hook = $opt_disable_paludis_hook\n";
         print "$tab"."opt_optimize_backups     = $opt_optimize_backups\n";

--- a/cfg-update.8
+++ b/cfg-update.8
@@ -66,9 +66,6 @@ With this option cfg\-update will output tags when starting or finishing subrout
 Check the index and rebuild if new packages have been installed (--index is used in the hooks for Portage and Paludis).
 The hook for Paludis will add an extra option --paludis behind --index. Paludis support is best\-effort and lightly tested; Portage is the primary supported package manager.
 .B
-.IP \-s,\ \-\-show\-protected\-dirs
-List all protected directories on your system.
-.B
 .IP \-\-optimize\-backups
 Creates extra backups which can be used for future automatic 3-way merging, so you don't have to update them manually.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -208,7 +208,6 @@ These enable stage 2's 3-way merges on subsequent updates.
 | `-b` / `--backups` | List available backups |
 | `-r N` / `--restore N` | Restore backup #N |
 | `--optimize-backups` | Remove redundant backups while keeping merge-capable pairs |
-| `--move-backups` | Migrate backup directory (used during package upgrades) |
 
 ## Key global paths
 

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -76,7 +76,6 @@ Every normal invocation (unless `--ebuild`) runs `check_hooks` and `check_tool` 
 | `-i`, `--index` | `check_index` | Yes | **High** |
 | `-b`, `--backups` | `list_backups` | No | Medium |
 | `-r`, `--restore` | `restore_backups` | Yes | Medium |
-| `-s`, `--show-protected-dirs` | `list_dirs` | No | Low (debug) |
 | `-a`, `--automatic-only` | (modifier for `-u`) | Yes | Medium (cron) |
 | `-m`, `--manual-only` | (modifier for `-u`) | Yes | Low |
 | `-p`, `--pretend` | (modifier) | Varies | Medium |
@@ -85,19 +84,16 @@ Every normal invocation (unless `--ebuild`) runs `check_hooks` and `check_tool` 
 | `-d`, `--debug` | `show_debug_info` | No | Low |
 | `-t`, `--tool` | Override merge tool | Varies | Medium |
 | `--paludis` | Sets Paludis mode for `--index` | Yes | Low |
-| `--move-backups` | `move_backups` | Yes | Low (migration) |
 | `--optimize-backups` | `optimize_backups` | Yes | Medium |
 | `--disable-portage-hook` | `disable_portage_hook` | Yes | Medium (uninstall) |
 | `--disable-paludis-hook` | `disable_paludis_hook` | Yes | Low |
 | `--ebuild` | Suppresses hooks/tool check | — | Internal (ebuild install) |
 | `--testsandbox` | Bypass `root_only` with `--ebuild` | — | Internal (test harness) |
 | `--help` | `print_usage` | No | **High** |
-| `file1 file2` | `diff_two_files` | Yes | Low |
-| `file1 file2 file3` | `diff_three_files` | Yes | Low |
 
 ---
 
-## Subroutine inventory (53 total)
+## Subroutine inventory
 
 ### Core update pipeline (keep)
 
@@ -130,7 +126,7 @@ Every normal invocation (unless `--ebuild`) runs `check_hooks` and `check_tool` 
 | Subroutine | Lines | Purpose |
 |------------|------:|---------|
 | `find_backups`, `list_backups`, `restore_backups` | 1788–1964 | Backup management |
-| `move_backups`, `optimize_backups` | 1964–2087 | Migration and cleanup |
+| `optimize_backups` | 1964–2087 | Backup seeding for future auto-merge |
 | `prepare_filenames_for_updating`, `prepare_filenames_for_restoring` | 934, 1803 | Path normalization |
 
 ### Merge tools (keep)
@@ -141,7 +137,6 @@ Every normal invocation (unless `--ebuild`) runs `check_hooks` and `check_tool` 
 | `check_gui` | 608 | X11 availability check |
 | `launch_tool` | 692 | Build per-tool command lines |
 | `tool_intro` | 2148 | User guidance per tool |
-| `diff_two_files`, `diff_three_files` | 2121–2148 | Ad-hoc diff mode |
 
 ### Utilities (keep)
 
@@ -159,6 +154,10 @@ Every normal invocation (unless `--ebuild`) runs `check_hooks` and `check_tool` 
 |-----------------------|----------|----------------|
 | ~~`breakpoint`~~ | Zero call sites | **Removed** (stage 3) |
 | ~~`test_code` / `--test`~~ | Empty stub; superseded by `test/run-tests.sh` | **Removed** (issue #27) |
+| ~~`list_dirs` / `-s`~~ | Debug wrapper over `portageq config_protect` | **Removed** (issue #28) |
+| ~~`diff_two_files`, `diff_three_files`~~ | Undocumented ad-hoc merge shortcut | **Removed** (issue #28) |
+| ~~`move_backups` / `--move-backups`~~ | Pre-1.8.0 inline backup migration | **Removed** (issue #28) |
+| ~~`$log_file`, `@merge_history`~~ | Only referenced in commented merge logging | **Removed** (issue #28) |
 | ~~emerge wrappers / phphelper~~ | Superseded by Portage bashrc hook | **Removed** (stage 3) |
 | Stale hook/merge messages in `cfg-update` | xxdiff defaults, "alias" wording | **Fixed** (stage 3) |
 
@@ -327,6 +326,7 @@ Each scenario has `etc/` (live + `._cfg*` files), optional `backups/etc/test/` (
 | ~~emerge wrapper scripts~~ | — | Removed (stage 3) |
 | ~~PHP helper~~ | — | Removed (stage 3) |
 | ~~`--test` stub / `test_code`~~ | — | Removed (issue #27); use `test/run-tests.sh` |
+| ~~`-s`, ad-hoc diff modes, `--move-backups`~~ | — | Removed (issue #28, 1.10.1) |
 | ~~`breakpoint` subroutine~~ | — | Removed (stage 3) |
 
 ---

--- a/gentoo/cfg-update-1.10.0.ebuild
+++ b/gentoo/cfg-update-1.10.0.ebuild
@@ -76,14 +76,6 @@ src_install() {
 }
 
 pkg_postinst() {
-
-	if [[ -z ${ROOT} ]]
-	then
-		ebegin "Moving backups to /var/lib/cfg-update/backups"
-		/usr/bin/cfg-update --ebuild --move-backups
-		eend $?
-	fi
-
 	echo
 	einfo "If this is a first time install, please check the configuration"
 	einfo "in /etc/cfg-update.conf before using cfg-update:"

--- a/test/README.md
+++ b/test/README.md
@@ -57,12 +57,12 @@ FEATURES=test USE=test emerge --oneshot app-portage/cfg-update
 | Tier | What | Checks |
 |------|------|--------|
 | 0 | static + lint | `perl -c`, `bash -n`, optional `shellcheck`, `lint-fixtures.sh` |
-| A | `-lv`, `-s` | Combined + per-scenario classify (12 markers), missing-index case, protected dirs, multi `CONFIG_PROTECT` dirs, ancestor backups on disk |
+| A | `-lv` | Combined + per-scenario classify (12 markers), missing-index case, removed-flag regression (`-s`, `--move-backups`, ad-hoc diff), multi `CONFIG_PROTECT` dirs, ancestor backups on disk |
 | B | `-p -au` | Stages 1–2 pretend; live files unchanged |
 | C | `-au` | Stages 1–2 execute: golden file equality, binary MD5, 3-way conflict handling, stage 3 re-list |
 | D | `-u` + stdin | Stages 3–5 execute (one stage enabled at a time): stage-specific output, mock 3-way merge, replace/keep filesystem outcomes |
 | E | `-i` / `-i -f` | Portage `--index`: up-to-date skip, stale rebuild from mock CONTENTS, marker-blocked skip, force rebuild |
-| F | `-b`, `-r`, `--optimize-backups` | Backup list/restore after stage-2 update; optimize-backups creates `._new-cfg_*` for unmodified files |
+| F | `-b`, `-r`, `--optimize-backups` | Backup list/restore after stage-2 update; stage-1 backups land in `BACKUP_PATH` (not inline); optimize-backups creates `._new-cfg_*` for unmodified files |
 
 Tier B/C/D/E/F pass `--testsandbox` with `--ebuild` so `-u`, `--index`, `-r`, and `--optimize-backups` skip the root check inside the temp sandbox.
 
@@ -70,7 +70,7 @@ Tier B/C/D/E/F pass `--testsandbox` with `--ebuild` so `-u`, `--index`, `-r`, an
 
 Scenarios exercised in Tier C/D include an `expected/` subdirectory with post-update reference files. Tier C compares live files with `cmp`. Tier D isolates a single manual stage per scenario (`stage3_only`, `stage4_only`, `stage5_only`), asserts stage-specific stdout (e.g. `manual 3-way merging` vs `manual updating`), and uses a mock `kdiff3` to verify 3-way merge invocation. Keys are piped to STDIN (sandbox `readkey` reads lines when stdin is not a TTY).
 
-The harness prepends a mock `portageq` to `PATH` that returns two sandbox directories as `CONFIG_PROTECT`: `etc/test` and `etc/test2` (the latter may be empty in most scenarios). Tier A `multi CONFIG_PROTECT` deploys stage-1 fixtures into both dirs and asserts `-s`, `-lv`, and `-b` see files from each protected path. Ancestor backups are placed at `BACKUP_PATH` + full dirname of each marker (e.g. `{sandbox}/var/lib/cfg-update/backups{sandbox}/etc/test/`), matching cfg-update's internal path logic.
+The harness prepends a mock `portageq` to `PATH` that returns two sandbox directories as `CONFIG_PROTECT`: `etc/test` and `etc/test2` (the latter may be empty in most scenarios). Tier A `multi CONFIG_PROTECT` deploys stage-1 fixtures into both dirs and asserts `-lv` and `-b` see files from each protected path. Ancestor backups are placed at `BACKUP_PATH` + full dirname of each marker (e.g. `{sandbox}/var/lib/cfg-update/backups{sandbox}/etc/test/`), matching cfg-update's internal path logic.
 
 ### Sandbox mode (stage 6c)
 

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -618,15 +618,29 @@ tier_a_no_index() {
         '<< Stage1 >>.*not found, skipping' "$output"
 }
 
-tier_a_protected_dirs() {
-    echo "=== Tier A: protected dirs (-s) ==="
-    setup_sandbox all
-    local output
+tier_a_removed_flags() {
+    echo "=== Tier A: removed flags regression ==="
+    local output f1 f2
+
     output="$(run_cfg_update -s 2>&1)" || true
-    assert_output_matches "protected dirs lists sandbox etc/test" \
-        "${SANDBOX}/etc/test" "$output"
-    assert_output_matches "protected dirs lists sandbox etc/test2" \
-        "${SANDBOX}/etc/test2" "$output"
+    assert_output_not_matches "removed flag: -s not accepted" \
+        'CONFIG_PROTECT|protected directories' "$output"
+    assert_output_matches "removed flag: -s shows usage" \
+        'missing valid options|USAGE' "$output"
+
+    output="$(run_cfg_update --move-backups 2>&1)" || true
+    assert_output_not_matches "removed flag: --move-backups not accepted" \
+        'Moving backup|move your backups' "$output"
+    assert_output_matches "removed flag: --move-backups shows usage" \
+        'missing valid options|USAGE' "$output"
+
+    f1="$FIXTURES/stage1-unmodified-text/etc/test_unmodified_file"
+    f2="$FIXTURES/stage1-unmodified-text/etc/._cfg0000_test_unmodified_file"
+    output="$(run_cfg_update "$f1" "$f2" 2>&1)" || true
+    assert_output_not_matches "removed mode: ad-hoc 2-file diff not accepted" \
+        'Merged output has been saved' "$output"
+    assert_output_matches "removed mode: ad-hoc 2-file diff shows usage" \
+        'missing valid options|USAGE' "$output"
 }
 
 tier_a_multi_config_protect() {
@@ -634,12 +648,6 @@ tier_a_multi_config_protect() {
     local output
 
     setup_multi_config_protect_sandbox auto
-    output="$(run_cfg_update -s 2>&1)" || true
-    assert_output_matches "multi-dir: protected lists etc/test" \
-        "${SANDBOX}/etc/test" "$output"
-    assert_output_matches "multi-dir: protected lists etc/test2" \
-        "${SANDBOX}/etc/test2" "$output"
-
     output="$(run_cfg_update -lv 2>&1)" || true
     assert_output_matches "multi-dir: classifies marker in etc/test" \
         'Stage\[1\][[:space:]]+Unmodified File[[:space:]].*etc/test/._cfg0000_test_unmodified_file' "$output"
@@ -911,6 +919,18 @@ tier_f_backups_maintenance() {
     assert_file_contains "optimize-backups backup matches live file" \
         "$backup_root/._new-cfg_test_unmodified_file" "#version 1.0"
 
+    setup_sandbox stage1-unmodified-text auto
+    backup_root="$SANDBOX/var/lib/cfg-update/backups${SANDBOX}/etc/test"
+    run_cfg_update -au >/dev/null
+    assert_file_exists "stage1 update created old backup in BACKUP_PATH" \
+        "$backup_root/._old-cfg_test_unmodified_file"
+    assert_file_exists "stage1 update created new backup in BACKUP_PATH" \
+        "$backup_root/._new-cfg_test_unmodified_file"
+    assert_missing "stage1 backups not written inline under etc/test (old)" \
+        "$SANDBOX/etc/test/._old-cfg_test_unmodified_file"
+    assert_missing "stage1 backups not written inline under etc/test (new)" \
+        "$SANDBOX/etc/test/._new-cfg_test_unmodified_file"
+
     setup_sandbox stage1-unmodified-text
     output="$(run_cfg_update --mount 2>&1)" || true
     assert_output_not_matches "removed flag: --mount not accepted" \
@@ -995,7 +1015,7 @@ main() {
     tier_a_classify_combined
     tier_a_per_scenario
     tier_a_no_index
-    tier_a_protected_dirs
+    tier_a_removed_flags
     tier_a_multi_config_protect
     tier_a_ancestor_backups
     tier_b_pretend_auto


### PR DESCRIPTION
## Summary

Prunes niche and debug-only features for the 1.10.1 development release (issue #28). Follows the same direct-removal pattern used for issue #27.

Closes #28

## Removed

- `-s` / `--show-protected-dirs` (`list_dirs` runmode; core `find_protected_dirs` unchanged)
- Undocumented ad-hoc diff modes (`cfg-update file1 file2` / `file1 file2 file3`)
- `--move-backups` and the ebuild `pkg_postinst` migration step
- Dead commented code and unused `$log_file` / `@merge_history` state

## Tests

- **Tier A** `tier_a_removed_flags`: regression checks that removed flags reject cleanly
- **Tier F** stage-1 backup test: verifies `._old-cfg_*` / `._new-cfg_*` land in `BACKUP_PATH`, not inline under `etc/test`
- Removed `tier_a_protected_dirs`; multi-`CONFIG_PROTECT` coverage retained via `-lv` / `-b`

`./test/run-tests.sh --full` — 190 passed

## Docs

Updated `cfg-update.8`, `ChangeLog`, `docs/INVENTORY.md`, `docs/ARCHITECTURE.md`, and `test/README.md`.

## Notes

- Version bumped to **1.10.1** — do not tag until approved
- `-d` / `--debug` intentionally retained (out of issue scope)
- Pre-1.8.0 inline backup migration is no longer performed on package upgrade