### PR TITLE
Align merge tool defaults and remove stale references (issue #25)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,11 @@
 # Copyright 2002-2005 Gentoo Technologies, Inc.; Distributed under the GPL v2
 # $Header: $
 
+*cfg-update-1.10.2 (18 JUN 2026)
+
+  Align merge tool defaults with cfg-update.conf (meld); list meld as the
+  primary example in help and docs; fix dead project URL (issue #25).
+
 *cfg-update-1.10.1 (18 JUN 2026)
 
   Prune niche/debug features: -s/--show-protected-dirs, ad-hoc diff modes,

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Feedback is welcome.
 
 A safe, staged alternative to Gentoo's `etc-update` for handling configuration file updates after package merges.
 
-**Version:** 1.10.1  
+**Version:** 1.10.2  
 **License:** GPL-2 ([COPYING](COPYING))
 
 ## Description

--- a/cfg-update
+++ b/cfg-update
@@ -35,10 +35,10 @@ $Term::ANSIColor::AUTORESET = 1;
 ######################################################################################################################
 
 # Setting program variables...
-    my $version           = "1.10.1";
+    my $version           = "1.10.2";
     my $progname          = basename($0);
     my $debug             = "2>/dev/null";
-    my $website           = "http://people.zeelandnet.nl/xentric";
+    my $website           = "https://github.com/rich0/cfg-update";
 # Set default settings...
     my $pkg_manager       = "Portage";
     my $install_log       = "/var/log/emerge.log";
@@ -522,7 +522,7 @@ sub check_gui{
         print "$tab"."  If you use this script on a system without an X-server you should permanently\n";
         print "$tab"."  set the MERGETOOL variable in $settings to vimdiff or sdiff.\n";
         print "$tab"."  I recommend the more advanced vimdiff on systems without an X-server.\n";
-        print "$tab"."  See $website for vimdiff usage instructions.\n\n";
+        print "$tab"."  See \"man cfg-update\" for merge tool usage instructions.\n\n";
         exit;
     }
     if ($opt_d >= 1) { $tab =~ s/    //; print "$tab"."</check_gui>\n"; }
@@ -1938,7 +1938,7 @@ sub print_usage{ #RUNMODE# -?, --help (or when no arguments or when unusable arg
         print "$tab"."\n";
         print "$tab"."  -t [tool], --tool [tool]\n";
         print "$tab"."          Set mergetool, overrides the default setting in $settings\n";
-        print "$tab"."          GUI tools: xxdiff, kdiff3, meld, tkdiff, gtkdiff, gvimdiff\n";
+        print "$tab"."          GUI tools: meld, kdiff3, xxdiff, tkdiff, gtkdiff, gvimdiff\n";
         print "$tab"."          CLI tools: vimdiff, sdiff, imediff2, imediff\n";
         print "$tab"."\n";
         print "$tab"."  -p, --pretend\n";

--- a/cfg-update.conf
+++ b/cfg-update.conf
@@ -4,10 +4,9 @@
 # | The recommended tool for merging is meld   but you can also use other    |
 # | tools if you don't like meld.  The Supported tools are listed below:     |
 # +----------+-----+--------------------------+------------------------------+
-# | beediff  | GUI | QT                       |                              |
-# | xxdiff   | GUI | KDE   (or Gnome with QT) |                              |
-# | kdiff3   | GUI | KDE   (or Gnome with QT) |                              |
 # | meld     | GUI | Gnome (or KDE with GTK)  |                              |
+# | kdiff3   | GUI | KDE   (or Gnome with QT) |                              |
+# | xxdiff   | GUI | KDE   (or Gnome with QT) |                              |
 # | gtkdiff  | GUI | Gnome (or KDE with GTK)  | STAGE 3 not supported!       |
 # | gvimdiff | GUI | Gnome (or KDE with GTK)  | STAGE 3 not supported!       |
 # | tkdiff   | GUI | Gnome (or KDE with TK)   |                              |
@@ -65,8 +64,8 @@ ENABLE_STAGE2 = yes
 # | If a merge-conflict has been detected in STAGE 2, you can now solve it   |
 # | manually in the MERGETOOL. Simply select the line(s) you need. When you  |
 # | are done, cfg-update will replace the current configuration file with the|
-# | merged result. Stage 3 works with xxdiff, beediff, kdiff3, meld, tkdiff, |
-# | gtkdiff.                                                                 |
+# | merged result. Stage 3 works with meld, kdiff3, xxdiff, tkdiff,      |
+# | imediff.                                                                 |
 # +--------------------------------------------------------------------------+
 ENABLE_STAGE3 = yes
 
@@ -148,7 +147,7 @@ ENABLE_STAGE5 = yes
 # PKG_DB       = /var/db/pkg                               # this directory contains the CONTENTS files (you can change it when your system uses another location)
 # INSTALL_LOG  = /var/log/emerge.log                       # emerge log used by --index to detect stale checksum indexes (Portage)
 # PALUDIS_HOOK = /usr/share/paludis/hooks/install_all_pre/cfg-update.bash  # best-effort; override if your Paludis hook path differs
-# XXDIFF_STYLE = "--style Keramik"                         # this variable controls the style of xxdiff
+# XXDIFF_STYLE = "--style Keramik"                         # optional style for xxdiff users
 #
 ##############################################################################
 #   IF YOU CHANGE THE FILENAME FORMAT VARIABLES, CFG-UPDATE WILL BE BROKEN!  #


### PR DESCRIPTION
Closes #25

## Summary

Aligns merge-tool messaging with the long-standing `meld` default in `cfg-update.conf`, without removing support for other tools such as xxdiff.

## Changes

- Point the in-script project URL at GitHub instead of the dead zeelandnet link
- Reference `man cfg-update` when GUI merge tools are unavailable
- List **meld** as the primary example in built-in help and `cfg-update.conf` comments
- Keep xxdiff and other tools documented as supported alternatives
- Bump version to **1.10.2** (`ChangeLog`, `README.md`)

## Testing

```bash
perl -c cfg-update
./test/run-tests.sh
```

190 passed, 0 failed