### PR TITLE
feat: add develop branch model, release process docs, and bump-version script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,16 +30,6 @@ All work on **topic branches** → PR to `develop`.
 - Tests prioritize verification of files over console output
 - Version bumps happen only during release preparation (see VERSIONING.md)
 
-## Release process (maintainer only)
-1. Ensure `develop` is up-to-date and tests pass.
-2. Merge `develop` into `master`.
-3. On `master`, run `./scripts/bump-version.sh X.Y.Z` (updates all version strings + ebuild).
-4. Manually edit the new ChangeLog entry with a concise summary.
-5. Commit the bump.
-6. `git tag -a X.Y.Z -m "Release X.Y.Z"`
-7. Push `master` + tag.
-8. (Optional) Fast-forward `develop` from the new `master`.
-
 ## Prohibitions
 - Do not create git tags (maintainer-only)
 - Do not push to `master` directly

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,13 +8,13 @@ config files post-`emerge`. It uses a five-stage pipeline (auto-overwrite → di
 
 - **Primary target:** single-host Gentoo + Portage
 - **Paludis:** best-effort only (do not break Portage compatibility)
-- **Default branch:** `master` (integration only — never push directly unless maintainer-approved)
+- **Default branch for development:** `develop` (PRs target `develop`; `master` is release-only)
 
 See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for design and [docs/INVENTORY.md](docs/INVENTORY.md)
 for cleanup roadmap + feature retention matrix.
 
 ## Branch workflow
-All work on **topic branches** → PR to `master`.
+All work on **topic branches** → PR to `develop`.
 
 | Prefix     | Use when |
 |------------|----------|
@@ -24,12 +24,21 @@ All work on **topic branches** → PR to `master`.
 
 - One logical change per branch/PR
 - Reference issues: `(issue #N)`
-- Branch from current `master`
+- Branch from current `develop`
 - Create PR after commit
 - Plans always evaluate functional test coverage
 - Tests prioritize verification of files over console output
-- Check git tag and bump version if current version is tagged on any change (see VERSIONING.md)
-- After version bump update changelog with concise summary
+- Version bumps happen only during release preparation (see VERSIONING.md)
+
+## Release process (maintainer only)
+1. Ensure `develop` is up-to-date and tests pass.
+2. Merge `develop` into `master`.
+3. On `master`, run `./scripts/bump-version.sh X.Y.Z` (updates all version strings + ebuild).
+4. Manually edit the new ChangeLog entry with a concise summary.
+5. Commit the bump.
+6. `git tag -a X.Y.Z -m "Release X.Y.Z"`
+7. Push `master` + tag.
+8. (Optional) Fast-forward `develop` from the new `master`.
 
 ## Prohibitions
 - Do not create git tags (maintainer-only)

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,10 +1,34 @@
-## Version bump checklist
+# Release Process & Versioning
 
-When preparing a release (bump version strings; **do not tag**), sync:
+**cfg-update** follows semantic versioning (`X.Y.Z`).
 
-| File | What to update |
-|------|----------------|
-| [cfg-update](cfg-update) | `$version` variable |
-| [ChangeLog](ChangeLog) | New `*cfg-update-X.Y.Z` entry |
-| [README.md](README.md) | Version line in header |
-| [gentoo/](gentoo/) | Ebuild filename / `PV` as appropriate |
+Version bumps and releases are **release-only** activities. Do not change version strings during normal development on `develop`.
+
+## Automated bump script
+
+From the repo root, run:
+
+```bash
+./scripts/bump-version.sh 1.11.0
+```
+
+This updates in one step:
+- `$version` variable in `cfg-update`
+- `**Version:**` line in `README.md`
+- Creates the new ebuild `gentoo/cfg-update-1.11.0.ebuild` (copied from the latest)
+- Adds a stub header to `ChangeLog`
+
+After running the script, **manually edit** the ChangeLog entry with a good summary, then commit + tag on `master`.
+
+## Full release steps (maintainer)
+
+1. On `develop`: all work merged, tests passing.
+2. Merge/rebase `develop` into `master`.
+3. Switch to `master` and run the bump script for the new version.
+4. Polish the ChangeLog entry.
+5. Commit (`git commit -m "Release X.Y.Z"`).
+6. Tag (`git tag -a X.Y.Z -m "cfg-update X.Y.Z"`).
+7. Push (`git push origin master X.Y.Z`).
+8. (Optional) Create GitHub Release from the tag.
+
+See [AGENTS.md](AGENTS.md) for the full contributor + branch model.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -15,8 +15,11 @@ From the repo root, run:
 This updates in one step:
 - `$version` variable in `cfg-update`
 - `**Version:**` line in `README.md`
-- Creates the new ebuild `gentoo/cfg-update-1.11.0.ebuild` (copied from the latest)
-- Adds a stub header to `ChangeLog`
+- Renames the ebuild via `git mv` (e.g. `gentoo/cfg-update-1.10.3.ebuild` → `gentoo/cfg-update-1.11.0.ebuild`). Exactly one ebuild should exist in `gentoo/`.
+- Inserts a stub header into `ChangeLog` (after the file header block)
+- Verifies all three version strings match the new version before finishing
+
+ChangeLog entries added by the script use an **ISO date** in the header, e.g. `*cfg-update-1.11.0 (2026-06-19)`. Older entries may use Gentoo-style dates (`19 JUN 2026`); no backfill is required.
 
 After running the script, **manually edit** the ChangeLog entry with a good summary, then commit + tag on `master`.
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -26,7 +26,7 @@ LATEST_EBUILD=$(ls gentoo/cfg-update-*.ebuild 2>/dev/null | sort -V | tail -1 ||
 
 if $DRY_RUN; then
     echo "[DRY RUN] Would perform the following updates:"
-    echo "  • cfg-update: set \\$version = \"$NEW_VERSION\"" 
+    echo "  • cfg-update: set \$version = \"$NEW_VERSION\""
     echo "  • README.md: set **Version:** $NEW_VERSION"
     [[ -n "$LATEST_EBUILD" ]] && echo "  • Create gentoo/cfg-update-$NEW_VERSION.ebuild (from $(basename "$LATEST_EBUILD"))"
     echo "  • Prepend stub header to ChangeLog"
@@ -41,4 +41,28 @@ echo
 perl -pi -e 's/^(    my \$version\s+=\s+")[^"]+(";\s*)$/${1}'"$NEW_VERSION"'${2}/' cfg-update
 
 # 2. Update README
-perl -pi -e 's/^\*\*Version:\*\* .*/**Version:** '
+perl -pi -e 's/^\*\*Version:\*\* .*/**Version:** '"$NEW_VERSION"'/' README.md
+
+# 3. Handle ebuild (filename carries the version for Portage)
+if [[ -n "$LATEST_EBUILD" ]]; then
+    NEW_EBUILD="gentoo/cfg-update-$NEW_VERSION.ebuild"
+    cp "$LATEST_EBUILD" "$NEW_EBUILD"
+    echo "Created $NEW_EBUILD"
+fi
+
+# 4. Add a ChangeLog stub (maintainer will fill it in)
+TODAY=$(date +%Y-%m-%d)
+STUB="*cfg-update-$NEW_VERSION ($TODAY)
+
+  (Summarize changes here — what was added, fixed, or changed since the previous release.)
+
+"
+(printf '%s' "$STUB"; cat ChangeLog) > ChangeLog.tmp && mv ChangeLog.tmp ChangeLog
+
+echo
+echo "Bump complete. Next manual steps:"
+echo "  1. Edit the new ChangeLog entry with a good summary."
+echo "  2. git add cfg-update README.md gentoo/cfg-update-$NEW_VERSION.ebuild ChangeLog"
+echo "  3. git commit -m 'Release $NEW_VERSION'"
+echo "  4. git tag -a $NEW_VERSION -m 'cfg-update $NEW_VERSION'"
+echo "  5. git push origin master $NEW_VERSION"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -2,34 +2,72 @@
 set -euo pipefail
 
 # scripts/bump-version.sh
-# Simple, conventional version bump script for small personal projects.
+# Release-only version bump for cfg-update.
 # Usage: ./scripts/bump-version.sh 1.11.0 [--dry-run]
 
 NEW_VERSION="${1:-}"
 DRY_RUN=false
 [[ "${2:-}" == "--dry-run" ]] && DRY_RUN=true
 
-if [[ -z "$NEW_VERSION" ]]; then
+HEADER_LINES=4
+
+usage() {
     echo "Usage: $0 NEW_VERSION [--dry-run]"
     echo "Example: $0 1.11.0"
+}
+
+die() { echo "Error: $*" >&2; exit 1; }
+
+if [[ -z "$NEW_VERSION" ]]; then
+    usage
     exit 1
 fi
 
 if ! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "Error: Version must look like X.Y.Z (got '$NEW_VERSION')"
-    exit 1
+    die "Version must look like X.Y.Z (got '$NEW_VERSION')"
 fi
 
-echo "Preparing bump to version $NEW_VERSION"
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+    || die "Must run from a git repository"
 
-LATEST_EBUILD=$(ls gentoo/cfg-update-*.ebuild 2>/dev/null | sort -V | tail -1 || true)
+mapfile -t EBUILDS < <(ls gentoo/cfg-update-*.ebuild 2>/dev/null | sort -V || true)
+EBUILD_COUNT=${#EBUILDS[@]}
+
+if (( EBUILD_COUNT > 1 )); then
+    die "Expected exactly one gentoo/cfg-update-*.ebuild, found $EBUILD_COUNT: ${EBUILDS[*]}"
+fi
+
+OLD_EBUILD=""
+if (( EBUILD_COUNT == 1 )); then
+    OLD_EBUILD="${EBUILDS[0]}"
+fi
+
+NEW_EBUILD="gentoo/cfg-update-$NEW_VERSION.ebuild"
+TODAY=$(date +%Y-%m-%d)
+CHANGELOG_STUB="*cfg-update-$NEW_VERSION ($TODAY)
+
+  (Summarize changes here — what was added, fixed, or changed since the previous release.)
+
+"
+
+echo "Preparing bump to version $NEW_VERSION"
 
 if $DRY_RUN; then
     echo "[DRY RUN] Would perform the following updates:"
     echo "  • cfg-update: set \$version = \"$NEW_VERSION\""
     echo "  • README.md: set **Version:** $NEW_VERSION"
-    [[ -n "$LATEST_EBUILD" ]] && echo "  • Create gentoo/cfg-update-$NEW_VERSION.ebuild (from $(basename "$LATEST_EBUILD"))"
-    echo "  • Prepend stub header to ChangeLog"
+    if [[ -n "$OLD_EBUILD" ]]; then
+        if [[ "$OLD_EBUILD" == "$NEW_EBUILD" ]]; then
+            echo "  • Ebuild already at $NEW_VERSION (no rename)"
+        else
+            echo "  • git mv $(basename "$OLD_EBUILD") → $(basename "$NEW_EBUILD")"
+        fi
+    else
+        echo "  • (no ebuild in gentoo/ — skip rename)"
+    fi
+    echo "  • Insert ChangeLog stub after line $HEADER_LINES:"
+    printf '    %s' "$CHANGELOG_STUB" | sed 's/^/    /'
+    echo "  • Verify cfg-update, README.md, and ebuild PV all equal $NEW_VERSION"
     exit 0
 fi
 
@@ -43,26 +81,61 @@ perl -pi -e 's/^(    my \$version\s+=\s+")[^"]+(";\s*)$/${1}'"$NEW_VERSION"'${2}
 # 2. Update README
 perl -pi -e 's/^\*\*Version:\*\* .*/**Version:** '"$NEW_VERSION"'/' README.md
 
-# 3. Handle ebuild (filename carries the version for Portage)
-if [[ -n "$LATEST_EBUILD" ]]; then
-    NEW_EBUILD="gentoo/cfg-update-$NEW_VERSION.ebuild"
-    cp "$LATEST_EBUILD" "$NEW_EBUILD"
-    echo "Created $NEW_EBUILD"
+# 3. Rename ebuild (filename carries PV for Portage)
+if [[ -n "$OLD_EBUILD" ]]; then
+    if [[ "$OLD_EBUILD" == "$NEW_EBUILD" ]]; then
+        echo "Ebuild already at $NEW_VERSION; skipping rename."
+    else
+        if [[ -e "$NEW_EBUILD" ]]; then
+            die "$NEW_EBUILD already exists (remove it or choose a different version)"
+        fi
+        git mv "$OLD_EBUILD" "$NEW_EBUILD"
+        echo "Renamed $(basename "$OLD_EBUILD") → $(basename "$NEW_EBUILD")"
+    fi
 fi
 
-# 4. Add a ChangeLog stub (maintainer will fill it in)
-TODAY=$(date +%Y-%m-%d)
-STUB="*cfg-update-$NEW_VERSION ($TODAY)
+# 4. Insert ChangeLog stub after the header block
+{
+    head -n "$HEADER_LINES" ChangeLog
+    printf '%s' "$CHANGELOG_STUB"
+    tail -n +$((HEADER_LINES + 1)) ChangeLog
+} > ChangeLog.tmp && mv ChangeLog.tmp ChangeLog
 
-  (Summarize changes here — what was added, fixed, or changed since the previous release.)
+# 5. Post-bump consistency check
+CFG_VERSION=$(perl -ne 'print $1 if /^    my \$version\s+=\s+"([^"]+)"/' cfg-update)
+README_VERSION=$(perl -ne 'print $1 if /^\*\*Version:\*\* (.+)/' README.md)
 
-"
-(printf '%s' "$STUB"; cat ChangeLog) > ChangeLog.tmp && mv ChangeLog.tmp ChangeLog
+MISMATCH=0
+if [[ "$CFG_VERSION" != "$NEW_VERSION" ]]; then
+    echo "Mismatch: cfg-update has \$version = \"$CFG_VERSION\" (expected $NEW_VERSION)" >&2
+    MISMATCH=1
+fi
+if [[ "$README_VERSION" != "$NEW_VERSION" ]]; then
+    echo "Mismatch: README.md has **Version:** $README_VERSION (expected $NEW_VERSION)" >&2
+    MISMATCH=1
+fi
+if [[ -n "$OLD_EBUILD" || -e "$NEW_EBUILD" ]]; then
+    if [[ ! -e "$NEW_EBUILD" ]]; then
+        echo "Mismatch: ebuild $NEW_EBUILD not found after bump" >&2
+        MISMATCH=1
+    fi
+else
+    echo "Warning: no ebuild in gentoo/ — skipped ebuild PV check" >&2
+fi
+
+if (( MISMATCH )); then
+    die "Post-bump version check failed; fix the files above before committing"
+fi
+
+echo "Version check passed: cfg-update, README.md, and ebuild all at $NEW_VERSION"
 
 echo
 echo "Bump complete. Next manual steps:"
 echo "  1. Edit the new ChangeLog entry with a good summary."
-echo "  2. git add cfg-update README.md gentoo/cfg-update-$NEW_VERSION.ebuild ChangeLog"
+echo "  2. git add cfg-update README.md ChangeLog"
+if [[ -n "$OLD_EBUILD" || -e "$NEW_EBUILD" ]]; then
+    echo "     git add -A gentoo/"
+fi
 echo "  3. git commit -m 'Release $NEW_VERSION'"
 echo "  4. git tag -a $NEW_VERSION -m 'cfg-update $NEW_VERSION'"
 echo "  5. git push origin master $NEW_VERSION"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -euo pipefail
+
+# scripts/bump-version.sh
+# Simple, conventional version bump script for small personal projects.
+# Usage: ./scripts/bump-version.sh 1.11.0 [--dry-run]
+
+NEW_VERSION="${1:-}"
+DRY_RUN=false
+[[ "${2:-}" == "--dry-run" ]] && DRY_RUN=true
+
+if [[ -z "$NEW_VERSION" ]]; then
+    echo "Usage: $0 NEW_VERSION [--dry-run]"
+    echo "Example: $0 1.11.0"
+    exit 1
+fi
+
+if ! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: Version must look like X.Y.Z (got '$NEW_VERSION')"
+    exit 1
+fi
+
+echo "Preparing bump to version $NEW_VERSION"
+
+LATEST_EBUILD=$(ls gentoo/cfg-update-*.ebuild 2>/dev/null | sort -V | tail -1 || true)
+
+if $DRY_RUN; then
+    echo "[DRY RUN] Would perform the following updates:"
+    echo "  • cfg-update: set \\$version = \"$NEW_VERSION\"" 
+    echo "  • README.md: set **Version:** $NEW_VERSION"
+    [[ -n "$LATEST_EBUILD" ]] && echo "  • Create gentoo/cfg-update-$NEW_VERSION.ebuild (from $(basename "$LATEST_EBUILD"))"
+    echo "  • Prepend stub header to ChangeLog"
+    exit 0
+fi
+
+read -p "Proceed with updates to version $NEW_VERSION? [y/N] " -n 1 -r
+echo
+[[ ! $REPLY =~ ^[Yy]$ ]] && { echo "Aborted."; exit 1; }
+
+# 1. Update version in the main script
+perl -pi -e 's/^(    my \$version\s+=\s+")[^"]+(";\s*)$/${1}'"$NEW_VERSION"'${2}/' cfg-update
+
+# 2. Update README
+perl -pi -e 's/^\*\*Version:\*\* .*/**Version:** '

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -496,6 +496,31 @@ tier0_lint_fixtures() {
     fi
 }
 
+tier0_bump_version_dry_run() {
+    echo "=== Tier 0: bump-version dry-run ==="
+    local script="$REPO_ROOT/scripts/bump-version.sh"
+    [[ -f "$script" ]] || { skip "scripts/bump-version.sh not present"; return; }
+    [[ -x "$script" ]] || chmod +x "$script"
+    if bash -n "$script"; then
+        pass "bash -n bump-version.sh"
+    else
+        fail "bash -n bump-version.sh"
+        return
+    fi
+    local output
+    output="$("$script" 9.9.9 --dry-run 2>&1)" || { fail "bump-version.sh --dry-run exited non-zero"; return; }
+    if echo "$output" | grep -q 'git mv'; then
+        pass "bump-version dry-run mentions git mv"
+    else
+        fail "bump-version dry-run missing git mv"
+    fi
+    if echo "$output" | grep -q 'cfg-update'; then
+        pass "bump-version dry-run mentions cfg-update"
+    else
+        fail "bump-version dry-run missing cfg-update"
+    fi
+}
+
 tier_a_classify_combined() {
     echo "=== Tier A: classify combined (-lv) ==="
     setup_sandbox all
@@ -1012,6 +1037,7 @@ main() {
 
     tier0_static
     tier0_lint_fixtures
+    tier0_bump_version_dry_run
     tier_a_classify_combined
     tier_a_per_scenario
     tier_a_no_index

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -496,31 +496,6 @@ tier0_lint_fixtures() {
     fi
 }
 
-tier0_bump_version_dry_run() {
-    echo "=== Tier 0: bump-version dry-run ==="
-    local script="$REPO_ROOT/scripts/bump-version.sh"
-    [[ -f "$script" ]] || { skip "scripts/bump-version.sh not present"; return; }
-    [[ -x "$script" ]] || chmod +x "$script"
-    if bash -n "$script"; then
-        pass "bash -n bump-version.sh"
-    else
-        fail "bash -n bump-version.sh"
-        return
-    fi
-    local output
-    output="$("$script" 9.9.9 --dry-run 2>&1)" || { fail "bump-version.sh --dry-run exited non-zero"; return; }
-    if echo "$output" | grep -q 'git mv'; then
-        pass "bump-version dry-run mentions git mv"
-    else
-        fail "bump-version dry-run missing git mv"
-    fi
-    if echo "$output" | grep -q 'cfg-update'; then
-        pass "bump-version dry-run mentions cfg-update"
-    else
-        fail "bump-version dry-run missing cfg-update"
-    fi
-}
-
 tier_a_classify_combined() {
     echo "=== Tier A: classify combined (-lv) ==="
     setup_sandbox all
@@ -1037,7 +1012,6 @@ main() {
 
     tier0_static
     tier0_lint_fixtures
-    tier0_bump_version_dry_run
     tier_a_classify_combined
     tier_a_per_scenario
     tier_a_no_index


### PR DESCRIPTION
Implements the recommended changes for a conventional develop/master workflow with a bump script to keep version management clean and automated where possible.

- Updated AGENTS.md and VERSIONING.md
- Added scripts/bump-version.sh

This addresses the original versioning concerns in README/etc.