### PR TITLE
test: prune overlapping assertions and reorganize tiers (issue #39)

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -57,7 +57,10 @@ FEATURES=test USE=test emerge --oneshot app-portage/cfg-update
 | Tier | What | Checks |
 |------|------|--------|
 | 0 | static + lint | `perl -c`, `bash -n`, optional `shellcheck`, `lint-fixtures.sh` |
-| A | `-lv` | Combined + per-scenario classify (12 markers), missing-index case, removed-flag regression (`-s`, `--move-backups`, ad-hoc diff), multi `CONFIG_PROTECT` dirs, ancestor backups on disk |
+| A1 | `-lv` combined | All 12 markers in one sandbox; validates `checksum.index.seed` integration |
+| A2 | `-lv` canaries | Per-scenario classify for four edge cases: sole marker, MF conflict, dual `._cfg*`, LL symlink |
+| A3 | edge cases | Missing index (`stage0-no-index`), multi `CONFIG_PROTECT` dirs |
+| A4 | removed flags | Regression for removed options: `-s`, `--move-backups`, ad-hoc diff, `--mount`, `-h1` |
 | B | `-p -au` | Stages 1–2 pretend; live files unchanged |
 | C | `-au` | Stages 1–2 execute: golden file equality, binary MD5, 3-way conflict handling, stage 3 re-list |
 | D | `-u` + stdin | Stages 3–5 execute (one stage enabled at a time): stage-specific output, mock 3-way merge, replace/keep filesystem outcomes |

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -537,10 +537,10 @@ tier_a_classify_combined() {
 }
 
 tier_a_per_scenario() {
-    echo "=== Tier A: classify per scenario (-lv) ==="
+    echo "=== Tier A: classify per scenario (-lv, canaries) ==="
     local output
 
-    # stage1-unmodified-text
+    # Canary: sole-marker isolation check
     setup_sandbox stage1-unmodified-text
     output="$(run_cfg_update -lv 2>&1)" || true
     assert_output_matches "isolated stage1-unmodified-text" \
@@ -548,21 +548,13 @@ tier_a_per_scenario() {
     assert_output_matches "isolated stage1-unmodified-text: only one marker" \
         '^1[[:space:]]+Stage\[1\]' "$output"
 
-    setup_sandbox stage1-unmodified-binary
-    output="$(run_cfg_update -lv 2>&1)" || true
-    assert_output_matches "isolated stage1-unmodified-binary" \
-        'Stage\[1\][[:space:]]+Unmodified Binary[[:space:]].*_cfg0000_test_unmodified_binary' "$output"
-
-    setup_sandbox stage2-3way-merge-success
-    output="$(run_cfg_update -lv 2>&1)" || true
-    assert_output_matches "isolated stage2-3way-merge-success" \
-        'Stage\[2\][[:space:]]+Modified File[[:space:]].*_cfg0000_test_auto_3way_success' "$output"
-
+    # Canary: MF conflict routing (distinct from success case)
     setup_sandbox stage2-3way-merge-conflict
     output="$(run_cfg_update -lv 2>&1)" || true
     assert_output_matches "isolated stage2-3way-merge-conflict" \
         'Stage\[2\][[:space:]]+Modified File[[:space:]].*_cfg0000_test_auto_3way_conflict' "$output"
 
+    # Canary: dual ._cfg0000_* / ._cfg0001_* markers on same basename
     setup_sandbox stage4-manual-2way
     output="$(run_cfg_update -lv 2>&1)" || true
     assert_output_matches "isolated stage4-manual-2way 0000" \
@@ -570,31 +562,7 @@ tier_a_per_scenario() {
     assert_output_matches "isolated stage4-manual-2way 0001" \
         'Stage\[4\][[:space:]]+Modified File[[:space:]].*_cfg0001_test_manual_2way' "$output"
 
-    setup_sandbox stage4-custom-file
-    output="$(run_cfg_update -lv 2>&1)" || true
-    assert_output_matches "isolated stage4-custom-file" \
-        'Stage\[4\][[:space:]]+Custom File[[:space:]].*_cfg0000_test_custom_file' "$output"
-
-    setup_sandbox stage5-modified-binary
-    output="$(run_cfg_update -lv 2>&1)" || true
-    assert_output_matches "isolated stage5-modified-binary" \
-        'Stage\[5\][[:space:]]+Modified Binary[[:space:]].*_cfg0000_test_modified_binary' "$output"
-
-    setup_sandbox stage5-custom-binary
-    output="$(run_cfg_update -lv 2>&1)" || true
-    assert_output_matches "isolated stage5-custom-binary" \
-        'Stage\[5\][[:space:]]+Custom Binary[[:space:]].*_cfg0000_test_custom_binary' "$output"
-
-    setup_sandbox stage5-file-to-link
-    output="$(run_cfg_update -lv 2>&1)" || true
-    assert_output_matches "isolated stage5-file-to-link" \
-        'Stage\[5\][[:space:]]+File to Link[[:space:]].*_cfg0000_test_file_2_link' "$output"
-
-    setup_sandbox stage5-link-to-file
-    output="$(run_cfg_update -lv 2>&1)" || true
-    assert_output_matches "isolated stage5-link-to-file" \
-        'Stage\[5\][[:space:]]+Link to File[[:space:]].*_cfg0000_test_link_2_file' "$output"
-
+    # Canary: LL state (symlink retarget)
     setup_sandbox stage5-link-to-link
     output="$(run_cfg_update -lv 2>&1)" || true
     assert_output_matches "isolated stage5-link-to-link" \
@@ -618,7 +586,7 @@ tier_a_no_index() {
         '<< Stage1 >>.*not found, skipping' "$output"
 }
 
-tier_a_removed_flags() {
+tier_a_removed_flags_regression() {
     echo "=== Tier A: removed flags regression ==="
     local output f1 f2
 
@@ -640,6 +608,19 @@ tier_a_removed_flags() {
     assert_output_not_matches "removed mode: ad-hoc 2-file diff not accepted" \
         'Merged output has been saved' "$output"
     assert_output_matches "removed mode: ad-hoc 2-file diff shows usage" \
+        'missing valid options|USAGE' "$output"
+
+    setup_sandbox stage1-unmodified-text
+    output="$(run_cfg_update --mount 2>&1)" || true
+    assert_output_not_matches "removed flag: --mount not accepted" \
+        'Mounts remote hosts|mount_hosts|sshfs' "$output"
+    assert_output_matches "removed flag: --mount shows usage" \
+        'missing valid options|USAGE' "$output"
+
+    output="$(run_cfg_update -h1 -l 2>&1)" || true
+    assert_output_not_matches "removed flag: -h1 not accepted" \
+        'Value out of range in -h|sshfs|remote host' "$output"
+    assert_output_matches "removed flag: -h1 shows usage" \
         'missing valid options|USAGE' "$output"
 }
 
@@ -664,16 +645,6 @@ tier_a_multi_config_protect() {
         '^[[:space:]]*1[[:space:]]' "$output"
     assert_output_matches "multi-dir: backup list second entry" \
         '^[[:space:]]*2[[:space:]]' "$output"
-}
-
-tier_a_ancestor_backups() {
-    echo "=== Tier A: ancestor backups on disk ==="
-    setup_sandbox all
-    local backup_root="$SANDBOX/var/lib/cfg-update/backups${SANDBOX}/etc/test"
-    assert_file_exists "ancestor: 3-way success" \
-        "$backup_root/._new-cfg_test_auto_3way_success"
-    assert_file_exists "ancestor: 3-way conflict" \
-        "$backup_root/._new-cfg_test_auto_3way_conflict"
 }
 
 tier_b_pretend_auto() {
@@ -794,8 +765,6 @@ tier_d_execute_manual() {
     setup_sandbox stage4-manual-2way stage4_only
     output="$(run_cfg_update_stdin $'1\n1\n' -u 2>&1)" || true
     assert_stage_output "stage4 manual replace" 4 "$output"
-    assert_output_matches "stage4 switches diff3 to sdiff" \
-        'diff3 cannot be used for this stage, changing to sdiff' "$output"
     assert_file_equals "stage4 manual replace matches golden" \
         "$SANDBOX/etc/test/test_manual_2way" \
         "$FIXTURES/stage4-manual-2way/expected/test_manual_2way"
@@ -930,19 +899,6 @@ tier_f_backups_maintenance() {
         "$SANDBOX/etc/test/._old-cfg_test_unmodified_file"
     assert_missing "stage1 backups not written inline under etc/test (new)" \
         "$SANDBOX/etc/test/._new-cfg_test_unmodified_file"
-
-    setup_sandbox stage1-unmodified-text
-    output="$(run_cfg_update --mount 2>&1)" || true
-    assert_output_not_matches "removed flag: --mount not accepted" \
-        'Mounts remote hosts|mount_hosts|sshfs' "$output"
-    assert_output_matches "removed flag: --mount shows usage" \
-        'missing valid options|USAGE' "$output"
-
-    output="$(run_cfg_update -h1 -l 2>&1)" || true
-    assert_output_not_matches "removed flag: -h1 not accepted" \
-        'Value out of range in -h|sshfs|remote host' "$output"
-    assert_output_matches "removed flag: -h1 shows usage" \
-        'missing valid options|USAGE' "$output"
 }
 
 tier_e_index_portage() {
@@ -1015,9 +971,8 @@ main() {
     tier_a_classify_combined
     tier_a_per_scenario
     tier_a_no_index
-    tier_a_removed_flags
+    tier_a_removed_flags_regression
     tier_a_multi_config_protect
-    tier_a_ancestor_backups
     tier_b_pretend_auto
     tier_c_execute_auto
     tier_d_execute_manual


### PR DESCRIPTION
## Summary

Light cleanup of the integration test harness per issue #39. Removes a small number of overlapping assertions and reorganizes Tier A documentation without dropping fixtures or functional tiers.

## Changes

- **Remove** `tier_a_ancestor_backups` — ancestor files already exercised by Tier C stage-2 paths and linted in `lint-fixtures.sh`
- **Trim** `tier_a_per_scenario` to four canary fixtures (`stage1-unmodified-text`, `stage2-3way-merge-conflict`, `stage4-manual-2way`, `stage5-link-to-link`); combined classify tier unchanged (all 12 markers)
- **Consolidate** removed-flag regression into `tier_a_removed_flags_regression` (`-s`, `--move-backups`, ad-hoc diff, `--mount`, `-h1`)
- **Drop** duplicate stage4 sdiff-switch assert (still covered by `assert_stage_output`)
- **Update** `test/README.md` with A1–A4 sub-tier layout

## Test results

```
./test/run-tests.sh --full
Results: 180 passed, 0 failed, 0 skipped
```

Down from 190 assertions; same functional coverage.

Closes #39