### PR TITLE
Branch protection: version check and ruleset docs (issue #47)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,5 +24,8 @@ jobs:
       - name: Perl syntax check
         run: perl -c cfg-update
 
+      - name: Check version consistency
+        run: ./scripts/check-version.sh
+
       - name: Run integration tests
         run: ./test/run-tests.sh --full

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -41,7 +41,7 @@ After running the script, **manually edit** the ChangeLog entry with a good summ
 5. Merge the PR.
 6. On `master`: tag (`git tag -a 1.11.0 -m "cfg-update 1.11.0"`), push the tag (`git push origin 1.11.0`).
 7. (Optional) Create a GitHub Release from the tag.
-8. (Optional) Merge `master` back into `develop` if versions diverged.
+8. Open **PR: `master` → `develop`** to bring the version bump and ChangeLog into `develop`. Required after every release — `develop` will not have the new version until this step.
 
 ## Branch protection (rulesets)
 
@@ -69,10 +69,4 @@ Configure at **Settings → Rules → Rulesets → New branch ruleset**. Use rul
 | Require status checks to pass | Yes — same `integration` check |
 | Require branches to be up to date before merging | Yes |
 
-**Default branch:** set to `develop` in **Settings → General** if still `master`.
-
-### What “up to date before merging” means
-
-This does not require rebasing on every push. It only blocks the **Merge** button when the PR branch is behind its base branch. Use **Update branch** on the PR, `git merge develop`, or `git rebase develop`, then wait for CI to pass on the updated head commit.
-
-See [AGENTS.md](AGENTS.md) for the full contributor + branch model.
+**Default branch:** keep `master` so the repo homepage reflects the latest release. PRs from contributors target `develop` by convention (see [AGENTS.md](AGENTS.md)).

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -4,6 +4,15 @@
 
 Version bumps and releases are **release-only** activities. Do not change version strings during normal development on `develop`.
 
+## Version consistency check
+
+[`scripts/check-version.sh`](scripts/check-version.sh) verifies that `cfg-update`, `README.md`, and the ebuild PV all agree. It does **not** use git and is safe to run in CI, locally, and from the ebuild test phase.
+
+```bash
+./scripts/check-version.sh          # all three sources must match
+./scripts/check-version.sh 1.11.0 # all three must equal 1.11.0
+```
+
 ## Automated bump script
 
 From the repo root, run:
@@ -17,21 +26,53 @@ This updates in one step:
 - `**Version:**` line in `README.md`
 - Renames the ebuild via `git mv` (e.g. `gentoo/cfg-update-1.10.3.ebuild` → `gentoo/cfg-update-1.11.0.ebuild`). Exactly one ebuild should exist in `gentoo/`.
 - Inserts a stub header into `ChangeLog` (after the file header block)
-- Verifies all three version strings match the new version before finishing
+- Runs `check-version.sh` to verify all three version strings match the new version
 
 ChangeLog entries added by the script use an **ISO date** in the header, e.g. `*cfg-update-1.11.0 (2026-06-19)`. Older entries may use Gentoo-style dates (`19 JUN 2026`); no backfill is required.
 
-After running the script, **manually edit** the ChangeLog entry with a good summary, then commit + tag on `master`.
+After running the script, **manually edit** the ChangeLog entry with a good summary, then open a release PR to `master`.
 
 ## Full release steps (maintainer)
 
 1. On `develop`: all work merged, tests passing.
-2. Merge/rebase `develop` into `master`.
-3. Switch to `master` and run the bump script for the new version.
-4. Polish the ChangeLog entry.
-5. Commit (`git commit -m "Release X.Y.Z"`).
-6. Tag (`git tag -a X.Y.Z -m "cfg-update X.Y.Z"`).
-7. Push (`git push origin master X.Y.Z`).
-8. (Optional) Create GitHub Release from the tag.
+2. Create a release branch from `develop` (e.g. `release/1.11.0`).
+3. On the release branch: run `./scripts/bump-version.sh 1.11.0`, polish the ChangeLog entry, and commit.
+4. Open **PR: release branch → `master`** — CI runs `perl -c`, `check-version.sh`, and `./test/run-tests.sh --full`.
+5. Merge the PR.
+6. On `master`: tag (`git tag -a 1.11.0 -m "cfg-update 1.11.0"`), push the tag (`git push origin 1.11.0`).
+7. (Optional) Create a GitHub Release from the tag.
+8. (Optional) Merge `master` back into `develop` if versions diverged.
+
+## Branch protection (rulesets)
+
+Configure at **Settings → Rules → Rulesets → New branch ruleset**. Use rulesets only (do not also add legacy branch protection rules for the same branches). Start with enforcement status **Evaluate**, then switch to **Active** once behavior is confirmed.
+
+### Ruleset: `protect-develop`
+
+| Setting | Value |
+|---------|-------|
+| Target branches | Include by name: `develop` |
+| Restrict deletions | Yes |
+| Block force pushes | Yes |
+| Require a pull request before merging | Yes (0 approvals OK for solo maintainer) |
+| Require status checks to pass | Yes — add `integration` (may appear as `Tests / integration`) |
+| Require branches to be up to date before merging | Yes |
+
+### Ruleset: `protect-master`
+
+| Setting | Value |
+|---------|-------|
+| Target branches | Include by name: `master` |
+| Restrict deletions | Yes |
+| Block force pushes | Yes |
+| Require a pull request before merging | Yes — all changes including releases |
+| Require status checks to pass | Yes — same `integration` check |
+| Require branches to be up to date before merging | Yes |
+
+**Default branch:** set to `develop` in **Settings → General** if still `master`.
+
+### What “up to date before merging” means
+
+This does not require rebasing on every push. It only blocks the **Merge** button when the PR branch is behind its base branch. Use **Update branch** on the PR, `git merge develop`, or `git rebase develop`, then wait for CI to pass on the updated head commit.
 
 See [AGENTS.md](AGENTS.md) for the full contributor + branch model.

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -18,6 +18,8 @@ usage() {
 
 die() { echo "Error: $*" >&2; exit 1; }
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 if [[ -z "$NEW_VERSION" ]]; then
     usage
     exit 1
@@ -102,32 +104,7 @@ fi
 } > ChangeLog.tmp && mv ChangeLog.tmp ChangeLog
 
 # 5. Post-bump consistency check
-CFG_VERSION=$(perl -ne 'print $1 if /^    my \$version\s+=\s+"([^"]+)"/' cfg-update)
-README_VERSION=$(perl -ne 'print $1 if /^\*\*Version:\*\* (.+)/' README.md)
-
-MISMATCH=0
-if [[ "$CFG_VERSION" != "$NEW_VERSION" ]]; then
-    echo "Mismatch: cfg-update has \$version = \"$CFG_VERSION\" (expected $NEW_VERSION)" >&2
-    MISMATCH=1
-fi
-if [[ "$README_VERSION" != "$NEW_VERSION" ]]; then
-    echo "Mismatch: README.md has **Version:** $README_VERSION (expected $NEW_VERSION)" >&2
-    MISMATCH=1
-fi
-if [[ -n "$OLD_EBUILD" || -e "$NEW_EBUILD" ]]; then
-    if [[ ! -e "$NEW_EBUILD" ]]; then
-        echo "Mismatch: ebuild $NEW_EBUILD not found after bump" >&2
-        MISMATCH=1
-    fi
-else
-    echo "Warning: no ebuild in gentoo/ — skipped ebuild PV check" >&2
-fi
-
-if (( MISMATCH )); then
-    die "Post-bump version check failed; fix the files above before committing"
-fi
-
-echo "Version check passed: cfg-update, README.md, and ebuild all at $NEW_VERSION"
+"$SCRIPT_DIR/check-version.sh" "$NEW_VERSION"
 
 echo
 echo "Bump complete. Next manual steps:"
@@ -136,6 +113,6 @@ echo "  2. git add cfg-update README.md ChangeLog"
 if [[ -n "$OLD_EBUILD" || -e "$NEW_EBUILD" ]]; then
     echo "     git add -A gentoo/"
 fi
-echo "  3. git commit -m 'Release $NEW_VERSION'"
-echo "  4. git tag -a $NEW_VERSION -m 'cfg-update $NEW_VERSION'"
-echo "  5. git push origin master $NEW_VERSION"
+echo "  3. Open a PR to master (see VERSIONING.md)"
+echo "  4. After merge: git tag -a $NEW_VERSION -m 'cfg-update $NEW_VERSION'"
+echo "  5. git push origin $NEW_VERSION"

--- a/scripts/check-version.sh
+++ b/scripts/check-version.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -euo pipefail
+
+# scripts/check-version.sh
+# Verify cfg-update, README.md, and ebuild PV agree (no git required).
+# Usage: ./scripts/check-version.sh [EXPECTED_VERSION]
+
+EXPECTED="${1:-}"
+
+die() { echo "Error: $*" >&2; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_ROOT"
+
+CFG_VERSION=$(perl -ne 'print $1 if /^    my \$version\s+=\s+"([^"]+)"/' cfg-update)
+README_VERSION=$(perl -ne 'print $1 if /^\*\*Version:\*\* (.+)/' README.md)
+
+mapfile -t EBUILDS < <(ls gentoo/cfg-update-*.ebuild 2>/dev/null | sort -V || true)
+EBUILD_COUNT=${#EBUILDS[@]}
+
+if (( EBUILD_COUNT > 1 )); then
+    die "Expected exactly one gentoo/cfg-update-*.ebuild, found $EBUILD_COUNT: ${EBUILDS[*]}"
+fi
+
+EBUILD_VERSION=""
+if (( EBUILD_COUNT == 1 )); then
+    EBUILD_BASENAME=$(basename "${EBUILDS[0]}")
+    if [[ "$EBUILD_BASENAME" =~ ^cfg-update-([0-9]+\.[0-9]+\.[0-9]+)\.ebuild$ ]]; then
+        EBUILD_VERSION="${BASH_REMATCH[1]}"
+    else
+        die "Cannot parse PV from ebuild filename: $EBUILD_BASENAME"
+    fi
+fi
+
+if [[ -z "$CFG_VERSION" ]]; then
+    die "Could not read \$version from cfg-update"
+fi
+if [[ -z "$README_VERSION" ]]; then
+    die "Could not read **Version:** from README.md"
+fi
+
+TARGET="$EXPECTED"
+if [[ -z "$TARGET" ]]; then
+    TARGET="$CFG_VERSION"
+fi
+
+if ! [[ "$TARGET" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    die "Version must look like X.Y.Z (got '$TARGET')"
+fi
+
+MISMATCH=0
+report_mismatch() {
+    local label="$1" actual="$2"
+    echo "Mismatch: $label has \"$actual\" (expected $TARGET)" >&2
+    MISMATCH=1
+}
+
+[[ "$CFG_VERSION" == "$TARGET" ]] || report_mismatch 'cfg-update \$version' "$CFG_VERSION"
+[[ "$README_VERSION" == "$TARGET" ]] || report_mismatch 'README.md **Version:**' "$README_VERSION"
+
+if (( EBUILD_COUNT == 1 )); then
+    [[ "$EBUILD_VERSION" == "$TARGET" ]] || report_mismatch 'ebuild PV' "$EBUILD_VERSION"
+else
+    echo "Warning: no ebuild in gentoo/ — skipped ebuild PV check" >&2
+fi
+
+if (( MISMATCH )); then
+    die "Version check failed"
+fi
+
+echo "Version check passed: cfg-update, README.md, and ebuild all at $TARGET"


### PR DESCRIPTION
## Summary

Implements the repo-side pieces for issue #47:

- **`scripts/check-version.sh`** — git-independent check that `cfg-update`, `README.md`, and ebuild PV agree
- **CI** — runs `check-version.sh` in the `Tests / integration` job (alongside existing `perl -c` and `run-tests.sh --full`)
- **`bump-version.sh`** — delegates post-bump verification to `check-version.sh`
- **`VERSIONING.md`** — documents repository rulesets for `develop` and `master`, PR-based release flow, and the version check

`test/run-tests.sh` is unchanged and does not call git.

## Verification

```bash
perl -c cfg-update
./scripts/check-version.sh
./test/run-tests.sh --full
```

180 passed, 0 failed.

## Maintainer follow-up (manual)

After this PR merges and CI has run once:

1. Keep **`master`** as the default branch (stable public view); PRs target `develop` by convention
2. Create rulesets `protect-develop` and `protect-master` (Settings → Rules → Rulesets)
3. Require the `integration` status check on both branches

Closes #47