### PR TITLE
test: version mismatch (do not merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Feedback is welcome.
 
 A safe, staged alternative to Gentoo's `etc-update` for handling configuration file updates after package merges.
 
-**Version:** 1.10.3
+**Version:** 9.9.9
 **License:** GPL-2 ([COPYING](COPYING))
 
 ## Description


### PR DESCRIPTION
Disposable PR for branch-protection smoke test (Test 2). Intentionally sets README version to 9.9.9. Expect CI failure. Close without merging.