### PR TITLE
docs: add xxdiff to recommended merge tools in DEPENDENCIES.md

### DIFF
--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -59,6 +59,7 @@ Pick one tool with the capabilities you need:
 |------|--------|:---:|----------------|-------|
 | **meld** | 2-way + 3-way | Yes | `dev-util/meld` | **Default** in `cfg-update.conf` |
 | kdiff3 | 2-way + 3-way | Yes | `dev-util/kdiff3` | KDE; solid 3-way |
+| xxdiff | 2-way + 3-way | Yes | — | KDE/Qt; solid 3-way; not in portage (~2011); install manually |
 | imediff2 | 2-way | No | varies | CLI; good for headless |
 | imediff | 2-way + 3-way | No | varies | CLI 3-way (2025 fork patch) |
 | sdiff | 2-way | No | `sys-apps/diffutils` | Fallback if configured tool missing |


### PR DESCRIPTION
Fixes #53

## Summary

Adds `xxdiff` to the recommended merge tools table in `docs/DEPENDENCIES.md`. The tool already has first-class support in the script (`launch_tool`, `check_gui`, `check_tool`, `tool_intro`), the config template (`cfg-update.conf`), and other docs (`ARCHITECTURE.md`, `INVENTORY.md`), but was missing from DEPENDENCIES.md.

## Change

New table row after `kdiff3`:

| xxdiff | 2-way + 3-way | Yes | — | KDE/Qt; solid 3-way; not in portage (~2011); install manually |

The Gentoo package column is `—` because `xxdiff` was removed from portage circa 2011 (per `INVENTORY.md`).

## Testing

```bash
perl -c cfg-update
./test/run-tests.sh --full
```

180 passed, 0 failed.