### PR TITLE
docs: align merge tool lists across DEPENDENCIES, conf, and ebuild

### DIFF
--- a/cfg-update.conf
+++ b/cfg-update.conf
@@ -10,8 +10,10 @@
 # | gtkdiff  | GUI | Gnome (or KDE with GTK)  | STAGE 3 not supported!       |
 # | gvimdiff | GUI | Gnome (or KDE with GTK)  | STAGE 3 not supported!       |
 # | tkdiff   | GUI | Gnome (or KDE with TK)   |                              |
+# | kompare  | GUI | KDE                      | STAGE 3 not supported!       |
 # | vimdiff  | CLI | Systems without X        | STAGE 3 not supported!       |
 # | sdiff    | CLI | Systems without X        | STAGE 3 not supported!       |
+# | imediff  | CLI | Systems without X        |                              |
 # | imediff2 | CLI | Systems without X        | STAGE 3 not supported!       |
 # +----------+-----+--------------------------+------------------------------+
 MERGE_TOOL = /usr/bin/meld

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -188,8 +188,8 @@ Interactive prompts for binaries, symlinks, and custom files.
 
 Builds tool-specific command lines. Tool capabilities are detected in `check_tool`:
 
-- **2-way:** kdiff3, xxdiff, sdiff, imediff2, meld, vimdiff, …
-- **3-way:** xxdiff, kdiff3, meld, tkdiff, imediff
+- **2-way:** meld, kdiff3, xxdiff, tkdiff, imediff, imediff2, sdiff, vimdiff, gvimdiff, kompare
+- **3-way:** meld, kdiff3, xxdiff, tkdiff, imediff
 - **GUI check:** `check_gui` runs only when `launch_tool` is about to execute a GUI-capable tool (not for `diff3`/`diff` in automatic stages)
 
 ## Backup system

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -60,10 +60,13 @@ Pick one tool with the capabilities you need:
 | **meld** | 2-way + 3-way | Yes | `dev-util/meld` | **Default** in `cfg-update.conf` |
 | kdiff3 | 2-way + 3-way | Yes | `dev-util/kdiff3` | KDE; solid 3-way |
 | xxdiff | 2-way + 3-way | Yes | — | KDE/Qt; solid 3-way; not in portage (~2011); install manually |
+| tkdiff | 2-way + 3-way | Yes | varies | Rare; Tcl/Tk GUI |
 | imediff2 | 2-way | No | varies | CLI; good for headless |
 | imediff | 2-way + 3-way | No | varies | CLI 3-way (2025 fork patch) |
 | sdiff | 2-way | No | `sys-apps/diffutils` | Fallback if configured tool missing |
-| vimdiff | 2-way | Optional | `app-editors/vim` | No X required |
+| vimdiff | 2-way | No | `app-editors/vim` | CLI; no X required |
+| gvimdiff | 2-way | Yes | `app-editors/vim` | GUI variant of vimdiff; requires X |
+| kompare | 2-way | Yes | `kde-apps/kompare` | KDE; 2-way only |
 
 Set in `/etc/cfg-update.conf`:
 

--- a/gentoo/cfg-update-1.10.3.ebuild
+++ b/gentoo/cfg-update-1.10.3.ebuild
@@ -75,9 +75,9 @@ pkg_postinst() {
 	einfo "in /etc/cfg-update.conf before using cfg-update:"
 	echo
 	einfo "If your system does not have an X-server installed you need to"
-	einfo "change the MERGE_TOOL to sdiff, imediff2 or vimdiff."
+	einfo "change the MERGE_TOOL to sdiff, imediff, imediff2, or vimdiff."
 	einfo "If you have X installed, set MERGE_TOOL to your favorite GUI tool:"
-	einfo "meld (default), kdiff3, gtkdiff, gvimdiff, tkdiff, imediff2"
+	einfo "meld (default), kdiff3, xxdiff, gtkdiff, gvimdiff, tkdiff, kompare"
 	echo
 	einfo "TIP: to maximize the chances of future automatic updates, run:"
 	einfo "cfg-update --optimize-backups"


### PR DESCRIPTION
Follow-up to #53 (PR #54 merged).

## Summary

Brings merge-tool documentation into parity across user-facing sources. No behavior changes.

## Changes

### `docs/DEPENDENCIES.md`
- Add **tkdiff**, **gvimdiff**, **kompare**
- Split vimdiff/gvimdiff rows (CLI vs GUI)
- gtkdiff intentionally omitted pending #55

### `cfg-update.conf`
- Add **imediff** and **kompare** to supported-tools table

### `gentoo/cfg-update-1.10.3.ebuild`
- Sync `pkg_postinst` tool hints with DEPENDENCIES/--help (add xxdiff, imediff, kompare)

### `docs/ARCHITECTURE.md`
- Expand explicit 2-way/3-way tool lists

## Deferred

- gtkdiff Stage 4 detection tracked in #55 (verify real tool capabilities before code change)

## Testing

```bash
perl -c cfg-update
./test/run-tests.sh --full
```

180 passed, 0 failed.