### PR TITLE
cleanup: remove imediff2 legacy; add imediff invocation tests

### DIFF
--- a/cfg-update
+++ b/cfg-update
@@ -558,7 +558,7 @@ sub check_tool{
         if ($opt_d >= 1) { print "$tab"."merge_tool_name                   = $merge_tool_name\n"; }
     }
 # Check if tool can handle manual 2-way merges...
-    if ($merge_tool =~ /\/kdiff3$|^kdiff3$|\/xxdiff$|^xxdiff$|\/sdiff$|^sdiff$|\/imediff2?$|^imediff2?$|\/meld$|^meld$|\/kompare$|^kompare$|\/tkdiff$|^tkdiff$|\/vimdiff$|^vimdiff$|\/gvimdiff$|^gvimdiff$/) {
+    if ($merge_tool =~ /\/kdiff3$|^kdiff3$|\/xxdiff$|^xxdiff$|\/sdiff$|^sdiff$|\/imediff$|^imediff$|\/meld$|^meld$|\/kompare$|^kompare$|\/tkdiff$|^tkdiff$|\/vimdiff$|^vimdiff$|\/gvimdiff$|^gvimdiff$/) {
         $tool_supports_2way = "yes";
         if ($opt_d >= 1) { print "$tab"."tool_supports_2way                = $tool_supports_2way\n"; }
     } else {
@@ -578,7 +578,7 @@ sub check_tool{
         if ($opt_d >= 1) { print "$tab"."stage3 disabled...\n"; }
     }
 # Check if tool saves .merge file when aborted...
-    if ($merge_tool_name =~ /\/kdiff3$|^kdiff3$|\/xxdiff$|^xxdiff$|\/imediff2?$|^imediff2?$|\/meld$|^meld$|\/tkdiff$|^tkdiff$|\/gtkdiff$|^gtkdiff$/) {
+    if ($merge_tool_name =~ /\/kdiff3$|^kdiff3$|\/xxdiff$|^xxdiff$|\/imediff$|^imediff$|\/meld$|^meld$|\/tkdiff$|^tkdiff$|\/gtkdiff$|^gtkdiff$/) {
         $tool_saves_mergefile_when_aborted = "yes";
         if ($opt_d >= 1) { print "$tab"."tool_saves_mergefile_when_aborted = $tool_saves_mergefile_when_aborted\n"; }
     } else {
@@ -614,7 +614,7 @@ sub launch_tool{ #ARGS# ("pretend|execute","mergetool")
     if  ($_[1] =~ /\/gvimdiff$|^gvimdiff$/ )                                 { $cmd = "$_[1] -c 'saveas $path_live' -c next -c 'setlocal nomodifiable readonly' -c prev $path_live $path_new --nofork 2>\&1>/dev/null"; }
     if  ($_[1] =~ /\/gtkdiff$|^gtkdiff$/   )                                 { $cmd = "$_[1] -o $path_merged $path_live $path_new $debug"; }
     if (($_[1] =~ /\/imediff$|^imediff$/   ) && ($threeway_update =~ "yes")) { $cmd = "$_[1] -a -o $path_merged $path_live $path_backup_new $path_new"; }
-    if (($_[1] =~ /\/imediff2?$|^imediff2?$/ ) && ($threeway_update =~ "no" )) { $cmd = "$_[1] -a -o $path_merged $path_live $path_new"; }
+    if (($_[1] =~ /\/imediff$|^imediff$/   ) && ($threeway_update =~ "no" )) { $cmd = "$_[1] -a -o $path_merged $path_live $path_new"; }
     if  ($_[1] =~ /\/sdiff$|^sdiff$/       )                                 { $cmd = "$_[1] -w $screenwidth -d -o $path_merged $path_live $path_new"; }
     if  ($_[1] =~ /\/diff3$|^diff3$/       )                                 { $cmd = "$_[1] -m $path_new $path_backup_new $path_live > $path_merged $debug"; } # by specifying $path_live as the third file, the current settings will will be placed lower in the merged file. this may prevent trouble in case of unsolved merge conflicts...
     if  ($_[1] =~ /\/diff$|^diff$/         )                                 { $cmd = "$_[1] -W $screenwidth $path_live $path_new $debug"; } # viewing only...
@@ -1945,7 +1945,7 @@ sub print_usage{ #RUNMODE# -?, --help (or when no arguments or when unusable arg
         print "$tab"."  -t [tool], --tool [tool]\n";
         print "$tab"."          Set mergetool, overrides the default setting in $settings\n";
         print "$tab"."          GUI tools: meld, kdiff3, xxdiff, tkdiff, gtkdiff, gvimdiff\n";
-        print "$tab"."          CLI tools: vimdiff, sdiff, imediff2, imediff\n";
+        print "$tab"."          CLI tools: vimdiff, sdiff, imediff\n";
         print "$tab"."\n";
         print "$tab"."  -p, --pretend\n";
         print "$tab"."          Pretend, simulate the update session without changing anything\n";

--- a/cfg-update.conf
+++ b/cfg-update.conf
@@ -14,7 +14,6 @@
 # | vimdiff  | CLI | Systems without X        | STAGE 3 not supported!       |
 # | sdiff    | CLI | Systems without X        | STAGE 3 not supported!       |
 # | imediff  | CLI | Systems without X        |                              |
-# | imediff2 | CLI | Systems without X        | STAGE 3 not supported!       |
 # +----------+-----+--------------------------+------------------------------+
 MERGE_TOOL = /usr/bin/meld
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -188,7 +188,7 @@ Interactive prompts for binaries, symlinks, and custom files.
 
 Builds tool-specific command lines. Tool capabilities are detected in `check_tool`:
 
-- **2-way:** meld, kdiff3, xxdiff, tkdiff, imediff, imediff2, sdiff, vimdiff, gvimdiff, kompare
+- **2-way:** meld, kdiff3, xxdiff, tkdiff, imediff, sdiff, vimdiff, gvimdiff, kompare
 - **3-way:** meld, kdiff3, xxdiff, tkdiff, imediff
 - **GUI check:** `check_gui` runs only when `launch_tool` is about to execute a GUI-capable tool (not for `diff3`/`diff` in automatic stages)
 

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -61,8 +61,7 @@ Pick one tool with the capabilities you need:
 | kdiff3 | 2-way + 3-way | Yes | `dev-util/kdiff3` | KDE; solid 3-way |
 | xxdiff | 2-way + 3-way | Yes | — | KDE/Qt; solid 3-way; not in portage (~2011); install manually |
 | tkdiff | 2-way + 3-way | Yes | varies | Rare; Tcl/Tk GUI |
-| imediff2 | 2-way | No | varies | CLI; good for headless |
-| imediff | 2-way + 3-way | No | varies | CLI 3-way (2025 fork patch) |
+| imediff | 2-way + 3-way | No | `dev-util/imediff` | CLI; good for headless (use 3.4.x+) |
 | sdiff | 2-way | No | `sys-apps/diffutils` | Fallback if configured tool missing |
 | vimdiff | 2-way | No | `app-editors/vim` | CLI; no X required |
 | gvimdiff | 2-way | Yes | `app-editors/vim` | GUI variant of vimdiff; requires X |

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -194,7 +194,7 @@ pre_pkg_setup() {
 | kdiff3 | yes | yes | yes | Optional |
 | xxdiff | yes | yes | yes | **Removed** from portage ~2011; still supported if installed |
 | tkdiff | yes | yes | yes | Rare |
-| imediff / imediff2 | yes | yes/no | no | Optional CLI |
+| imediff | yes | yes | no | Optional CLI (`dev-util/imediff`) |
 | sdiff | yes | no | no | **Core** — always available |
 | vimdiff / gvimdiff | yes | no | mixed | Optional |
 | gtkdiff | yes | no | yes | Optional |

--- a/gentoo/cfg-update-1.10.3.ebuild
+++ b/gentoo/cfg-update-1.10.3.ebuild
@@ -75,7 +75,7 @@ pkg_postinst() {
 	einfo "in /etc/cfg-update.conf before using cfg-update:"
 	echo
 	einfo "If your system does not have an X-server installed you need to"
-	einfo "change the MERGE_TOOL to sdiff, imediff, imediff2, or vimdiff."
+	einfo "change the MERGE_TOOL to sdiff, imediff, or vimdiff."
 	einfo "If you have X installed, set MERGE_TOOL to your favorite GUI tool:"
 	einfo "meld (default), kdiff3, xxdiff, gtkdiff, gvimdiff, tkdiff, kompare"
 	echo

--- a/test/README.md
+++ b/test/README.md
@@ -67,7 +67,7 @@ Tier B/C/D/E/F pass `--testsandbox` with `--ebuild` so `-u`, `--index`, `-r`, an
 
 ### Golden `expected/` files
 
-Scenarios exercised in Tier C/D include an `expected/` subdirectory with post-update reference files. Tier C compares live files with `cmp`. Tier D isolates a single manual stage per scenario (`stage3_only`, `stage4_only`, `stage5_only`), asserts stage-specific stdout (e.g. `manual 3-way merging` vs `manual updating`), and uses a mock `kdiff3` to verify 3-way merge invocation. Keys are piped to STDIN (sandbox `readkey` reads lines when stdin is not a TTY).
+Scenarios exercised in Tier C/D include an `expected/` subdirectory with post-update reference files. Tier C compares live files with `cmp`. Tier D isolates a single manual stage per scenario (`stage3_only`, `stage4_only`, `stage5_only`), asserts stage-specific stdout (e.g. `manual 3-way merging` vs `manual updating`), and uses mock `kdiff3`, `sdiff`, and `imediff` binaries to verify merge-tool command invocations. Keys are piped to STDIN (sandbox `readkey` reads lines when stdin is not a TTY).
 
 The harness prepends a mock `portageq` to `PATH` that returns two sandbox directories as `CONFIG_PROTECT`: `etc/test` and `etc/test2` (the latter may be empty in most scenarios). Tier A `multi CONFIG_PROTECT` deploys stage-1 fixtures into both dirs and asserts `-lv` and `-b` see files from each protected path. Ancestor backups are placed at `BACKUP_PATH` + full dirname of each marker (e.g. `{sandbox}/var/lib/cfg-update/backups{sandbox}/etc/test/`), matching cfg-update's internal path logic.
 

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -348,6 +348,40 @@ assert_stage_output() {
     esac
 }
 
+install_mock_imediff() {
+    local golden_merge="${1:-}"
+    cat >"$SANDBOX/bin/imediff" <<'EOF'
+#!/bin/bash
+log="${CFG_UPDATE_TEST_SANDBOX}/mock-imediff.log"
+echo "$*" >>"$log"
+outfile=""
+use_a="no"
+files=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -a) use_a="yes"; shift ;;
+        -o) outfile="$2"; shift 2 ;;
+        *) files+=("$1"); shift ;;
+    esac
+done
+if [[ "$use_a" == "yes" ]]; then
+    echo "USE_A=yes" >>"$log"
+fi
+case "${#files[@]}" in
+    3) echo "THREE_WAY=yes" >>"$log" ;;
+    2) echo "TWO_WAY=yes" >>"$log" ;;
+esac
+if [[ -n "$outfile" && -f "${CFG_UPDATE_TEST_SANDBOX}/golden.merge" ]]; then
+    cp "${CFG_UPDATE_TEST_SANDBOX}/golden.merge" "$outfile"
+fi
+exit 0
+EOF
+    chmod +x "$SANDBOX/bin/imediff"
+    if [[ -n "$golden_merge" ]]; then
+        cp "$golden_merge" "$SANDBOX/golden.merge"
+    fi
+}
+
 install_mock_sdiff() {
     local golden_merge="${1:-}"
     cat >"$SANDBOX/bin/sdiff" <<'EOF'
@@ -746,6 +780,21 @@ tier_d_execute_manual() {
         "$SANDBOX/etc/test/test_auto_3way_conflict" \
         "$FIXTURES/stage2-3way-merge-conflict/expected/test_auto_3way_conflict.after_replace"
 
+    # Stage 3: mock imediff must receive 3-way (-a -o live ancestor new)
+    setup_sandbox stage2-3way-merge-conflict stage3_only
+    install_mock_imediff \
+        "$FIXTURES/stage2-3way-merge-conflict/expected/test_auto_3way_conflict.after_replace"
+    sed -i "s|^MERGE_TOOL = .*|MERGE_TOOL = $SANDBOX/bin/imediff|" "$SANDBOX/etc/cfg-update.conf"
+    output="$(run_cfg_update_stdin $'y\n1\n' -u 2>&1)" || true
+    assert_stage_output "stage3 conflict mock imediff merge" 3 "$output"
+    assert_file_contains "stage3 mock imediff used -a" \
+        "$SANDBOX/mock-imediff.log" "USE_A=yes"
+    assert_file_contains "stage3 mock imediff used 3-way merge" \
+        "$SANDBOX/mock-imediff.log" "THREE_WAY=yes"
+    assert_file_equals "stage3 mock imediff merge matches golden" \
+        "$SANDBOX/etc/test/test_auto_3way_conflict" \
+        "$FIXTURES/stage2-3way-merge-conflict/expected/test_auto_3way_conflict.after_replace"
+
     # Stage 4: mock sdiff must run 2-way merge (no -b ancestor)
     setup_sandbox stage4-manual-2way stage4_only
     install_mock_sdiff "$FIXTURES/stage4-manual-2way/expected/test_manual_2way"
@@ -759,6 +808,29 @@ tier_d_execute_manual() {
         "$SANDBOX/etc/test/test_manual_2way" \
         "$FIXTURES/stage4-manual-2way/expected/test_manual_2way"
     assert_missing "stage4 mock merge removed cfg0000 marker" \
+        "$SANDBOX/etc/test/._cfg0000_test_manual_2way"
+
+    # Stage 4: mock imediff must run 2-way merge (-a -o live new)
+    setup_sandbox stage4-manual-2way stage4_only
+    install_mock_imediff "$FIXTURES/stage4-manual-2way/expected/test_manual_2way"
+    sed -i "s|^MERGE_TOOL = .*|MERGE_TOOL = $SANDBOX/bin/imediff|" "$SANDBOX/etc/cfg-update.conf"
+    output="$(run_cfg_update_stdin $'y\n1\ny\n1\n' -u 2>&1)" || true
+    assert_output_matches "stage4 imediff merge: stage banner" \
+        "<< Stage4 >>" "$output"
+    assert_output_matches "stage4 imediff merge: 2-way merge mode" \
+        'manual 2-way merging, starting' "$output"
+    assert_output_not_matches "stage4 imediff merge: not 3-way mode" \
+        'manual 3-way merging, starting' "$output"
+    assert_output_not_matches "stage4 imediff merge: no diff3 switch" \
+        'diff3 cannot be used for this stage, changing to sdiff' "$output"
+    assert_file_contains "stage4 mock imediff used -a" \
+        "$SANDBOX/mock-imediff.log" "USE_A=yes"
+    assert_file_contains "stage4 mock imediff used 2-way merge" \
+        "$SANDBOX/mock-imediff.log" "TWO_WAY=yes"
+    assert_file_equals "stage4 mock imediff merge matches golden" \
+        "$SANDBOX/etc/test/test_manual_2way" \
+        "$FIXTURES/stage4-manual-2way/expected/test_manual_2way"
+    assert_missing "stage4 mock imediff merge removed cfg0000 marker" \
         "$SANDBOX/etc/test/._cfg0000_test_manual_2way"
 
     # Stage 4: replace (MF, no ancestor — must not run stage 3/5 handlers)


### PR DESCRIPTION
Fixes #57

## Summary

Verifies and locks in modern `imediff` command invocations for stages 3 and 4. Upstream [osamuaoki/imediff](https://github.com/osamuaoki/imediff) confirms the existing `launch_tool()` strings are correct (`-a -o` with live/ancestor/new file order). No invocation changes.

Removes legacy `imediff2` support and aligns docs to `dev-util/imediff` 3.4.x+.

## Changes

- Add `install_mock_imediff()` and Tier D tests for stage 3 (3-way) and stage 4 (2-way)
- Remove `imediff2` from `check_tool` regexes, `--help`, and `launch_tool` 2-way match
- Update `cfg-update.conf`, `DEPENDENCIES.md`, `ARCHITECTURE.md`, `INVENTORY.md`, ebuild

## Testing

```bash
perl -c cfg-update
./test/run-tests.sh --full
```

196 passed, 0 failed.