### PR TITLE
cleanup: remove gtkdiff from supported merge tools

### DIFF
--- a/cfg-update
+++ b/cfg-update
@@ -509,7 +509,7 @@ sub build_index{
 }
 
 sub launched_tool_needs_gui { #ARGS# ($tool_path)
-    return ($_[0] =~ /\/xxdiff$|^xxdiff$|\/kdiff3$|^kdiff3$|\/meld$|^meld$|\/kompare$|^kompare$|\/tkdiff$|^tkdiff$|\/gtkdiff$|^gtkdiff$|\/gvimdiff$|^gvimdiff$/);
+    return ($_[0] =~ /\/xxdiff$|^xxdiff$|\/kdiff3$|^kdiff3$|\/meld$|^meld$|\/kompare$|^kompare$|\/tkdiff$|^tkdiff$|\/gvimdiff$|^gvimdiff$/);
 }
 
 sub check_gui{
@@ -578,7 +578,7 @@ sub check_tool{
         if ($opt_d >= 1) { print "$tab"."stage3 disabled...\n"; }
     }
 # Check if tool saves .merge file when aborted...
-    if ($merge_tool_name =~ /\/kdiff3$|^kdiff3$|\/xxdiff$|^xxdiff$|\/imediff2?$|^imediff2?$|\/meld$|^meld$|\/tkdiff$|^tkdiff$|\/gtkdiff$|^gtkdiff$/) {
+    if ($merge_tool_name =~ /\/kdiff3$|^kdiff3$|\/xxdiff$|^xxdiff$|\/imediff2?$|^imediff2?$|\/meld$|^meld$|\/tkdiff$|^tkdiff$/) {
         $tool_saves_mergefile_when_aborted = "yes";
         if ($opt_d >= 1) { print "$tab"."tool_saves_mergefile_when_aborted = $tool_saves_mergefile_when_aborted\n"; }
     } else {
@@ -612,7 +612,6 @@ sub launch_tool{ #ARGS# ("pretend|execute","mergetool")
     if (($_[1] =~ /\/tkdiff$|^tkdiff$/     ) && ($threeway_update =~ "no" )) { $cmd = "$_[1] $path_live $path_new -o $path_merged $debug"; }
     if  ($_[1] =~ /\/vimdiff$|^vimdiff$/   )                                 { $cmd = "$_[1] -c 'saveas $path_live' -c next -c 'setlocal nomodifiable readonly' -c prev $path_live $path_new --nofork $debug"; }
     if  ($_[1] =~ /\/gvimdiff$|^gvimdiff$/ )                                 { $cmd = "$_[1] -c 'saveas $path_live' -c next -c 'setlocal nomodifiable readonly' -c prev $path_live $path_new --nofork 2>\&1>/dev/null"; }
-    if  ($_[1] =~ /\/gtkdiff$|^gtkdiff$/   )                                 { $cmd = "$_[1] -o $path_merged $path_live $path_new $debug"; }
     if (($_[1] =~ /\/imediff$|^imediff$/   ) && ($threeway_update =~ "yes")) { $cmd = "$_[1] -a -o $path_merged $path_live $path_backup_new $path_new"; }
     if (($_[1] =~ /\/imediff2?$|^imediff2?$/ ) && ($threeway_update =~ "no" )) { $cmd = "$_[1] -a -o $path_merged $path_live $path_new"; }
     if  ($_[1] =~ /\/sdiff$|^sdiff$/       )                                 { $cmd = "$_[1] -w $screenwidth -d -o $path_merged $path_live $path_new"; }
@@ -1842,10 +1841,6 @@ sub tool_intro{ #ARGS# ("mergetoolname")
         print "$tab"."  In $_[0] you select the lines that you want to keep.\n";
         print "$tab"."  When done, save the merged result with the \"Save & Exit\" button!\n";
         print "$tab"."  When you exit $_[0], $progname will finish the update...\n";
-    } elsif ($_[0] =~ /^gtkdiff$/) {
-        print "$tab"."  In $_[0] you select the lines that you want to keep.\n";
-        print "$tab"."  When done, save the merged result with menu: merge -> output file!\n";
-        print "$tab"."  When you exit $_[0], $progname will finish the update...\n";
     } else {
         print "$tab"."  In $_[0] you select the lines that you want to keep.\n";
         print "$tab"."  When done, try saving the merged result as *.merge\n";
@@ -1944,7 +1939,7 @@ sub print_usage{ #RUNMODE# -?, --help (or when no arguments or when unusable arg
         print "$tab"."\n";
         print "$tab"."  -t [tool], --tool [tool]\n";
         print "$tab"."          Set mergetool, overrides the default setting in $settings\n";
-        print "$tab"."          GUI tools: meld, kdiff3, xxdiff, tkdiff, gtkdiff, gvimdiff\n";
+        print "$tab"."          GUI tools: meld, kdiff3, xxdiff, tkdiff, gvimdiff\n";
         print "$tab"."          CLI tools: vimdiff, sdiff, imediff2, imediff\n";
         print "$tab"."\n";
         print "$tab"."  -p, --pretend\n";

--- a/cfg-update.conf
+++ b/cfg-update.conf
@@ -7,7 +7,6 @@
 # | meld     | GUI | Gnome (or KDE with GTK)  |                              |
 # | kdiff3   | GUI | KDE   (or Gnome with QT) |                              |
 # | xxdiff   | GUI | KDE   (or Gnome with QT) |                              |
-# | gtkdiff  | GUI | Gnome (or KDE with GTK)  | STAGE 3 not supported!       |
 # | gvimdiff | GUI | Gnome (or KDE with GTK)  | STAGE 3 not supported!       |
 # | tkdiff   | GUI | Gnome (or KDE with TK)   |                              |
 # | kompare  | GUI | KDE                      | STAGE 3 not supported!       |

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -197,7 +197,6 @@ pre_pkg_setup() {
 | imediff / imediff2 | yes | yes/no | no | Optional CLI |
 | sdiff | yes | no | no | **Core** — always available |
 | vimdiff / gvimdiff | yes | no | mixed | Optional |
-| gtkdiff | yes | no | yes | Optional |
 | kompare | yes | no | yes | KDE; rare |
 | diff3 | auto | — | no | **Core** (stage 2 internal) |
 

--- a/gentoo/cfg-update-1.10.3.ebuild
+++ b/gentoo/cfg-update-1.10.3.ebuild
@@ -77,7 +77,7 @@ pkg_postinst() {
 	einfo "If your system does not have an X-server installed you need to"
 	einfo "change the MERGE_TOOL to sdiff, imediff, imediff2, or vimdiff."
 	einfo "If you have X installed, set MERGE_TOOL to your favorite GUI tool:"
-	einfo "meld (default), kdiff3, xxdiff, gtkdiff, gvimdiff, tkdiff, kompare"
+	einfo "meld (default), kdiff3, xxdiff, gvimdiff, tkdiff, kompare"
 	echo
 	einfo "TIP: to maximize the chances of future automatic updates, run:"
 	einfo "cfg-update --optimize-backups"


### PR DESCRIPTION
Fixes #55

## Summary

Removes `gtkdiff` from supported merge tools. Investigation (see issue comment) confirmed it is no longer packaged on Gentoo, depends on obsolete GNOME libraries, and was only half-integrated in cfg-update (`launch_tool` had a command branch but `check_tool` omitted it from the 2-way regex, disabling stage 4).

Users who build gtkdiff themselves can still set `MERGE_TOOL` to it; the tool falls through to the generic unsupported-tool command path.

## Changes

- Remove gtkdiff from `launched_tool_needs_gui`, `tool_saves_mergefile_when_aborted`, `launch_tool`, `tool_intro`, and `--help`
- Remove gtkdiff row from `cfg-update.conf` supported-tools table
- Remove gtkdiff from `INVENTORY.md` and ebuild `pkg_postinst` hints

## Note

Independent of PR #58 (imediff cleanup). Both touch `ebuild`/`cfg-update.conf` — merge order may require a trivial conflict resolution.

## Testing

```bash
perl -c cfg-update
./test/run-tests.sh --full
```

180 passed, 0 failed.