### PR TITLE
feature: validate markers against Portage CONTENTS before ancestor promote (issue #66)

### DIFF
--- a/cfg-update
+++ b/cfg-update
@@ -955,6 +955,126 @@ sub make_temp_backups{ #ARGS# ("pretend|execute")
     if ($opt_d >= 1) { $tab =~ s/    //; print "$tab"."</make_temp_backups>\n"; }
 }
 
+# Look up Portage VDB CONTENTS MD5 for the live config path (issue #66).
+# Uses the package with the highest BUILD_TIME (last install); falls back to
+# CONTENTS mtime when BUILD_TIME is missing. Does not read checksum.index.
+# Returns ($status, $md5_or_reason): status is "ok" or "unavailable".
+# All inputs via parameters — no package globals.
+sub lookup_contents_md5_for_live { #ARGS# ($path_live, $pkg_manager, $pkg_db)
+    my ($path_live, $pkg_manager, $pkg_db) = @_;
+    if (!defined $path_live || $path_live eq "") {
+        return ("unavailable", "empty path");
+    }
+    if (!defined $pkg_manager || $pkg_manager !~ /^portage$/i) {
+        return ("unavailable", "not Portage");
+    }
+    if (!defined $pkg_db || $pkg_db eq "" || !-d $pkg_db) {
+        return ("unavailable", "no pkg_db");
+    }
+
+    my $best_md5;
+    my $best_time = -1;
+
+    opendir(my $cat_dh, $pkg_db) or return ("unavailable", "cannot open pkg_db");
+    while (defined(my $category = readdir($cat_dh))) {
+        next if $category eq "." || $category eq "..";
+        my $cat_path = "$pkg_db/$category";
+        next unless -d $cat_path;
+        opendir(my $pkg_dh, $cat_path) or next;
+        while (defined(my $pkg = readdir($pkg_dh))) {
+            next if $pkg eq "." || $pkg eq "..";
+            my $pkg_path = "$cat_path/$pkg";
+            my $contents = "$pkg_path/CONTENTS";
+            next unless -f $contents;
+
+            my $install_time = 0;
+            if (open(my $bt, "<", "$pkg_path/BUILD_TIME")) {
+                my $line = <$bt>;
+                close($bt);
+                if (defined $line && $line =~ /^\s*(\d+)\s*$/) {
+                    $install_time = $1 + 0;
+                }
+            }
+            if ($install_time <= 0) {
+                $install_time = (stat($contents))[9] // 0;
+            }
+
+            open(my $fh, "<", $contents) or next;
+            while (defined(my $line = <$fh>)) {
+                # Portage: obj <path> <md5> <mtime>
+                if ($line =~ /^obj\s+(\S+)\s+([0-9a-fA-F]{32})\b/) {
+                    my ($obj_path, $md5) = ($1, lc($2));
+                    if ($obj_path eq $path_live && $install_time >= $best_time) {
+                        $best_time = $install_time;
+                        $best_md5 = $md5;
+                    }
+                }
+            }
+            close($fh);
+        }
+        closedir($pkg_dh);
+    }
+    closedir($cat_dh);
+
+    if (!defined $best_md5) {
+        return ("unavailable", "no CONTENTS match");
+    }
+    return ("ok", $best_md5);
+}
+
+# Promote staged marker snapshot ($path_temp_new) to permanent Stage 2 ancestor
+# ($path_backup_new) only when it still matches Portage CONTENTS for $path_live
+# (issue #66). On mismatch: warn and skip promote. On missing VDB: fail open.
+# Returns 1 if promoted (or would under pretend), 0 if skipped for mismatch.
+# All inputs via parameters — no package globals. Caller still removes temp_new.
+sub promote_backup_new { #ARGS# ($mode, $path_temp_new, $path_backup_new, $path_live, $pkg_manager, $pkg_db, $enable_backups, $indent)
+    my ($mode, $path_temp_new, $path_backup_new, $path_live,
+        $pkg_manager, $pkg_db, $enable_backups, $indent) = @_;
+    $indent = "" if !defined $indent;
+    $mode = "" if !defined $mode;
+
+    if (!defined $enable_backups || $enable_backups !~ /^yes$|^true$|^on$/i) {
+        return 1;
+    }
+    if (!defined $path_temp_new || $path_temp_new eq "" || !-e $path_temp_new) {
+        return 1;
+    }
+    if (!defined $path_backup_new || $path_backup_new eq "") {
+        return 1;
+    }
+
+    my $marker_md5 = "";
+    {
+        my $out = `md5sum "$path_temp_new" 2>/dev/null`;
+        if (defined $out && $out =~ /^([0-9a-fA-F]{32})\b/) {
+            $marker_md5 = lc($1);
+        }
+    }
+
+    my ($status, $detail) = lookup_contents_md5_for_live($path_live, $pkg_manager, $pkg_db);
+
+    if ($status eq "ok") {
+        my $contents_md5 = $detail;
+        if ($marker_md5 ne "" && $marker_md5 eq $contents_md5) {
+            if ($mode =~ /execute/) {
+                `cp -pP "$path_temp_new" "$path_backup_new" 2>/dev/null`;
+            }
+            return 1;
+        }
+        print BOLD YELLOW "$indent"."* Warning: Portage marker does not match CONTENTS MD5 for $path_live\n";
+        print "$indent"."  marker MD5=$marker_md5 CONTENTS MD5=$contents_md5\n";
+        print BOLD YELLOW "$indent"."* Not promoting tampered marker as Stage 2 ancestor (._new-cfg_*)\n";
+        return 0;
+    }
+
+    # unavailable: fail open (maintain prior promote behavior)
+    print BOLD YELLOW "$indent"."* Warning: cannot validate marker against Portage CONTENTS ($detail); promoting ancestor as usual\n";
+    if ($mode =~ /execute/) {
+        `cp -pP "$path_temp_new" "$path_backup_new" 2>/dev/null`;
+    }
+    return 1;
+}
+
 # Disposable /tmp view of one non-live merge input so accidental tool saves cannot
 # corrupt permanent backups or Portage markers (issue #65; Stage 4: issue #68).
 # Orthogonal to make_temp_backups (which stages permanent backup promotion).
@@ -1545,8 +1665,9 @@ sub update_merge_complete{ #ARGS# ("pretend|execute")
     if ($_[0] =~ /execute/) { `cp -pP "$path_temp_old" "$path_backup_old" $debug`; }
     if (($opt_v >= 1) || ($opt_d >= 1)) { print "$tab"."  rm -f \"$path_temp_old\"\n"; }
     if ($_[0] =~ /execute/) { `rm -f "$path_temp_old" $debug`; }
-    if (($opt_v >= 1) || ($opt_d >= 1)) { print "$tab"."  cp -pP \"$path_temp_new\" \"$path_backup_new\"\n"; }
-    if ($_[0] =~ /execute/) { `cp -pP "$path_temp_new" "$path_backup_new" $debug`; }
+    # Validate marker vs Portage CONTENTS before writing Stage 2 ancestor (issue #66).
+    promote_backup_new($_[0], $path_temp_new, $path_backup_new, $path_live,
+                       $pkg_manager, $pkg_db, $enable_backups, $tab);
     if (($opt_v >= 1) || ($opt_d >= 1)) { print "$tab"."  rm -f \"$path_temp_new\"\n"; }
     if ($_[0] =~ /execute/) { `rm -f "$path_temp_new" $debug`; }
     if (($opt_v >= 1) || ($opt_d >= 1)) { if ($is_executable =~ "yes") { print "$tab"."  chmod +x $path_live\n"; }}
@@ -1571,8 +1692,9 @@ sub update_replace_complete{ #ARGS# ("pretend|execute")
     if ($_[0] =~ /execute/) { `cp -pP "$path_temp_old" "$path_backup_old" $debug`; }
     if (($opt_v >= 1) || ($opt_d >= 1)) { print "$tab"."  rm -f \"$path_temp_old\"\n"; }
     if ($_[0] =~ /execute/) { `rm -f "$path_temp_old" $debug`; }
-    if (($opt_v >= 1) || ($opt_d >= 1)) { print "$tab"."  cp -pP \"$path_temp_new\" \"$path_backup_new\"\n"; }
-    if ($_[0] =~ /execute/) { `cp -pP "$path_temp_new" "$path_backup_new" $debug`; }
+    # Validate marker vs Portage CONTENTS before writing Stage 2 ancestor (issue #66).
+    promote_backup_new($_[0], $path_temp_new, $path_backup_new, $path_live,
+                       $pkg_manager, $pkg_db, $enable_backups, $tab);
     if (($opt_v >= 1) || ($opt_d >= 1)) { print "$tab"."  rm -f \"$path_temp_new\"\n"; }
     if ($_[0] =~ /execute/) { `rm -f "$path_temp_new" $debug`; }
     if (($opt_v >= 1) || ($opt_d >= 1)) { print "$tab"."  rm -f \"$path_merged\" (should not exist!)\n"; }
@@ -1592,8 +1714,9 @@ sub update_keep_complete{ #ARGS# ("pretend|execute")
     if ($_[0] =~ /execute/) { `cp -pP "$path_temp_old" "$path_backup_old" $debug`; }
     if (($opt_v >= 1) || ($opt_d >= 1)) { print "$tab"."  rm -f \"$path_temp_old\"\n"; }
     if ($_[0] =~ /execute/) { `rm -f "$path_temp_old" $debug`; }
-    if (($opt_v >= 1) || ($opt_d >= 1)) { print "$tab"."  cp -pP \"$path_temp_new\" \"$path_backup_new\"\n"; }
-    if ($_[0] =~ /execute/) { `cp -pP "$path_temp_new" "$path_backup_new" $debug`; }
+    # Validate marker vs Portage CONTENTS before writing Stage 2 ancestor (issue #66).
+    promote_backup_new($_[0], $path_temp_new, $path_backup_new, $path_live,
+                       $pkg_manager, $pkg_db, $enable_backups, $tab);
     if (($opt_v >= 1) || ($opt_d >= 1)) { print "$tab"."  rm -f \"$path_temp_new\"\n"; }
     if ($_[0] =~ /execute/) { `rm -f "$path_temp_new" $debug`; }
     if (($opt_v >= 1) || ($opt_d >= 1)) { print "$tab"."  rm -f \"$path_merged\" (should not exist)\n"; }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -205,6 +205,15 @@ Backups live under `/var/lib/cfg-update/backups/`, mirroring the original path:
 
 These enable stage 2's 3-way merges on subsequent updates.
 
+Before writing `._new-cfg_*`, cfg-update compares the staged marker snapshot
+(`$path_temp_new`) to the Portage VDB `CONTENTS` MD5 for the **live path**
+(not the checksum index, and not the `._cfg*` filename). The digest is taken
+from the most recently installed package that owns that path (`BUILD_TIME`,
+else CONTENTS mtime). On match, the ancestor is promoted as usual. On
+mismatch, a warning is printed and the bad content is **not** stored as the
+Stage 2 ancestor (issue #66). If CONTENTS is missing, unparseable, or the
+manager is not Portage, promotion fails open (prior behavior) with a warning.
+
 | Command | Purpose |
 |---------|---------|
 | `-b` / `--backups` | List available backups |

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -106,6 +106,7 @@ Every normal invocation (unless `--ebuild`) runs `check_hooks` and `check_tool` 
 | `update_stage1`–`update_stage5` | Per-stage logic |
 | `update_retry`, `update_canceled`, `update_merge_*`, `update_replace_complete`, `update_keep_complete` | Interactive update handlers |
 | `make_temp_backups` | Temp files during merge |
+| `lookup_contents_md5_for_live`, `promote_backup_new` | Validate marker vs Portage CONTENTS before Stage 2 ancestor promote (issue #66) |
 
 ### Index and hooks
 

--- a/test/README.md
+++ b/test/README.md
@@ -62,8 +62,9 @@ FEATURES=test USE=test emerge --oneshot app-portage/cfg-update
 | D | `-u` + stdin | Stages 3–5 execute (one stage enabled at a time): stage-specific output, mock 3-way merge, replace/keep filesystem outcomes |
 | E | `-i` / `-i -f` | Portage `--index`: up-to-date skip, stale rebuild from mock CONTENTS, marker-blocked skip, force rebuild |
 | F | `-b`, `-r`, `--optimize-backups` | Backup list/restore after stage-2 update; stage-1 backups land in `BACKUP_PATH` (not inline); optimize-backups creates `._new-cfg_*` for unmodified files |
+| G | CONTENTS promote validation | Issue #66: pristine marker promotes `._new-cfg_*`; tampered marker does not poison ancestor; missing CONTENTS fails open; last-install `BUILD_TIME` wins |
 
-Tier B/C/D/E/F pass `--testsandbox` with `--ebuild` so `-u`, `--index`, `-r`, and `--optimize-backups` skip the root check inside the temp sandbox.
+Tier B/C/D/E/F/G pass `--testsandbox` with `--ebuild` so `-u`, `--index`, `-r`, and `--optimize-backups` skip the root check inside the temp sandbox.
 
 ### Golden `expected/` files
 

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -143,6 +143,7 @@ write_test_config() {
     local conf="$1" index="$2" backup="$3"
     local stages="${4:-all}"
     local merge_tool="${5:-/usr/bin/diff3}"
+    local pkg_db="${6:-}"
     local s1=yes s2=yes s3=yes s4=yes s5=yes
     if [[ "$stages" == "auto" ]]; then
         s3=no s4=no s5=no
@@ -166,6 +167,23 @@ ENABLE_STAGE5 = $s5
 INDEX_FILE = $index
 BACKUP_PATH = $backup
 EOF
+    if [[ -n "$pkg_db" ]]; then
+        echo "PKG_DB = $pkg_db" >>"$conf"
+    fi
+}
+
+# Install a Portage CONTENTS entry for a live path (issue #66 promote validation).
+# Args: live_abs_path md5 [pkg_slot_dir relative to SANDBOX/var/db/pkg] [BUILD_TIME]
+install_contents_obj() {
+    local live_path="$1"
+    local md5="$2"
+    local slot_rel="${3:-app-test/test-pkg-1.0}"
+    local build_time="${4:-1000}"
+    local pkg_dir="$SANDBOX/var/db/pkg/$slot_rel"
+    mkdir -p "$pkg_dir"
+    # Append so multi-package scenarios can stack entries in separate slots.
+    echo "obj $live_path $md5 0" >>"$pkg_dir/CONTENTS"
+    echo "$build_time" >"$pkg_dir/BUILD_TIME"
 }
 
 install_portageq_mock() {
@@ -1129,6 +1147,90 @@ tier_e_index_portage() {
         'Stage\[1\][[:space:]]+Unmodified File[[:space:]].*_cfg0000_test_unmodified_file' "$output"
 }
 
+tier_g_contents_promote_validation() {
+    echo "=== Tier G: CONTENTS marker promote validation (issue #66) ==="
+    local output backup_root live marker_md5 pristine_marker
+
+    # --- Pristine marker: CONTENTS matches → promote ._new-cfg_* ---
+    setup_sandbox stage1-unmodified-text auto
+    live="$SANDBOX/etc/test/test_unmodified_file"
+    pristine_marker="$SANDBOX/etc/test/._cfg0000_test_unmodified_file"
+    marker_md5="$(md5sum "$pristine_marker" | awk '{print $1}')"
+    install_contents_obj "$live" "$marker_md5" "app-test/test-pkg-1.0" "2000"
+    # Point PKG_DB at sandbox VDB (not host /var/db/pkg).
+    echo "PKG_DB = $SANDBOX/var/db/pkg" >>"$SANDBOX/etc/cfg-update.conf"
+
+    run_cfg_update -au >/dev/null
+    backup_root="$SANDBOX/var/lib/cfg-update/backups${SANDBOX}/etc/test"
+    assert_file_exists "pristine CONTENTS: promoted new-cfg ancestor" \
+        "$backup_root/._new-cfg_test_unmodified_file"
+    assert_md5_equals "pristine CONTENTS: ancestor MD5 equals marker" \
+        "$backup_root/._new-cfg_test_unmodified_file" "$marker_md5"
+    assert_missing "pristine CONTENTS: cfg marker removed after stage1" \
+        "$SANDBOX/etc/test/._cfg0000_test_unmodified_file"
+
+    # --- Tampered marker: CONTENTS still pristine → do not poison ancestor ---
+    setup_sandbox stage1-unmodified-text auto
+    live="$SANDBOX/etc/test/test_unmodified_file"
+    pristine_marker="$SANDBOX/etc/test/._cfg0000_test_unmodified_file"
+    marker_md5="$(md5sum "$pristine_marker" | awk '{print $1}')"
+    install_contents_obj "$live" "$marker_md5" "app-test/test-pkg-1.0" "2000"
+    echo "PKG_DB = $SANDBOX/var/db/pkg" >>"$SANDBOX/etc/cfg-update.conf"
+    # External pre-session tamper (the footgun issue #66 covers).
+    printf 'TAMPERED-MARKER\n' >"$pristine_marker"
+
+    output="$(run_cfg_update -au 2>&1)" || true
+    backup_root="$SANDBOX/var/lib/cfg-update/backups${SANDBOX}/etc/test"
+    assert_output_matches "tampered marker: CONTENTS mismatch warning" \
+        'does not match CONTENTS MD5' "$output"
+    assert_output_matches "tampered marker: refused Stage 2 ancestor promote" \
+        'Not promoting tampered marker' "$output"
+    # Stage1 still applies the (tampered) marker to the live file.
+    assert_file_contains "tampered marker: live update still completed" \
+        "$live" "TAMPERED-MARKER"
+    assert_missing "tampered marker: cfg marker still removed" \
+        "$SANDBOX/etc/test/._cfg0000_test_unmodified_file"
+    if [[ -f "$backup_root/._new-cfg_test_unmodified_file" ]]; then
+        if grep -q 'TAMPERED-MARKER' "$backup_root/._new-cfg_test_unmodified_file"; then
+            fail "tampered marker: ancestor must not contain TAMPERED content"
+        else
+            pass "tampered marker: existing ancestor not poisoned with TAMPERED"
+        fi
+    else
+        pass "tampered marker: no new-cfg ancestor written"
+    fi
+
+    # --- Missing CONTENTS: fail open → still promote (regression guard) ---
+    setup_sandbox stage1-unmodified-text auto
+    # Explicit empty pkg_db so host VDB cannot interfere.
+    mkdir -p "$SANDBOX/var/db/pkg-empty"
+    echo "PKG_DB = $SANDBOX/var/db/pkg-empty" >>"$SANDBOX/etc/cfg-update.conf"
+    output="$(run_cfg_update -au 2>&1)" || true
+    backup_root="$SANDBOX/var/lib/cfg-update/backups${SANDBOX}/etc/test"
+    assert_output_matches "missing CONTENTS: fail-open validation warning" \
+        'cannot validate marker against Portage CONTENTS' "$output"
+    assert_file_exists "missing CONTENTS: still promoted new-cfg ancestor" \
+        "$backup_root/._new-cfg_test_unmodified_file"
+
+    # --- Multi-package: last install (higher BUILD_TIME) wins ---
+    setup_sandbox stage1-unmodified-text auto
+    live="$SANDBOX/etc/test/test_unmodified_file"
+    pristine_marker="$SANDBOX/etc/test/._cfg0000_test_unmodified_file"
+    marker_md5="$(md5sum "$pristine_marker" | awk '{print $1}')"
+    # Older package has a wrong/stale MD5; newer package has the real marker MD5.
+    install_contents_obj "$live" "00000000000000000000000000000000" \
+        "app-test/old-pkg-1.0" "1000"
+    install_contents_obj "$live" "$marker_md5" \
+        "app-test/new-pkg-2.0" "9000"
+    echo "PKG_DB = $SANDBOX/var/db/pkg" >>"$SANDBOX/etc/cfg-update.conf"
+    run_cfg_update -au >/dev/null
+    backup_root="$SANDBOX/var/lib/cfg-update/backups${SANDBOX}/etc/test"
+    assert_file_exists "last-install CONTENTS: promoted new-cfg ancestor" \
+        "$backup_root/._new-cfg_test_unmodified_file"
+    assert_md5_equals "last-install CONTENTS: ancestor matches newer package MD5" \
+        "$backup_root/._new-cfg_test_unmodified_file" "$marker_md5"
+}
+
 main() {
     parse_args "$@"
 
@@ -1155,6 +1257,7 @@ main() {
     tier_d_execute_manual
     tier_e_index_portage
     tier_f_backups_maintenance
+    tier_g_contents_promote_validation
 
     echo ""
     echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"


### PR DESCRIPTION
## Summary

- Before promoting a staged `._cfg*` snapshot to `._new-cfg_*` (Stage 2 ancestor), compare its MD5 to Portage VDB `CONTENTS` for the **live path**, using the most recently installed package (`BUILD_TIME`, else CONTENTS mtime).
- On mismatch: warn and **do not** store the tampered marker as the ancestor; live update still completes.
- On missing/unparseable VDB or non-Portage: fail open with a warning (maintainer guidance on #66).
- New helpers `lookup_contents_md5_for_live` and `promote_backup_new` take all inputs via parameters/returns (no new global coupling).
- Wired into `update_merge_complete`, `update_replace_complete`, and `update_keep_complete`.
- Tier G file-focused tests: pristine promote, tampered skip, missing CONTENTS fail-open, last-install wins.
- Brief docs in ARCHITECTURE + INVENTORY.

Closes #66

## Test plan

- [x] `perl -c cfg-update`
- [x] `./test/run-tests.sh --full` (227 passed)
- [ ] Review warning wording for mismatch vs fail-open paths